### PR TITLE
Add react-native migration docs along with a few UI fixes

### DIFF
--- a/content/docs/developer-admin-dashboard/okto-faucet.mdx
+++ b/content/docs/developer-admin-dashboard/okto-faucet.mdx
@@ -33,13 +33,13 @@ Okto Credits are testnet tokens ($OKTO) that serve as the native fee token on th
 
 ### **Need Testnet/Mainnet Funds? Fill out the form below:**
 
-<div style={{ width: '80%', maxWidth: '600px', margin: '0 auto' }}>
+<div style={{ width: '100%', maxWidth: '100%', margin: '0 auto' }}>
   <iframe
     id="typeform-widget"
     title="Troubleshooting Form"
     src="https://coindcx.typeform.com/to/oXtDR5xw"
     width="100%"
-    height="580px"
+    height="450px"
     frameBorder="0"
     allowFullScreen
     style={{ 

--- a/content/docs/developer-admin-dashboard/okto-faucet.mdx
+++ b/content/docs/developer-admin-dashboard/okto-faucet.mdx
@@ -39,7 +39,7 @@ Okto Credits are testnet tokens ($OKTO) that serve as the native fee token on th
     title="Troubleshooting Form"
     src="https://coindcx.typeform.com/to/oXtDR5xw"
     width="100%"
-    height="450px"
+    height="470px"
     frameBorder="0"
     allowFullScreen
     style={{ 

--- a/content/docs/developer-admin-dashboard/sponsorship.mdx
+++ b/content/docs/developer-admin-dashboard/sponsorship.mdx
@@ -46,7 +46,7 @@ Sponsorship integrates with Okto's wallet infrastructure to automatically cover 
     title="Troubleshooting Form"
     src="https://coindcx.typeform.com/to/oXtDR5xw"
     width="100%"
-    height="450px"
+    height="470px"
     frameBorder="0"
     allowFullScreen
     style={{ 

--- a/content/docs/developer-admin-dashboard/sponsorship.mdx
+++ b/content/docs/developer-admin-dashboard/sponsorship.mdx
@@ -38,15 +38,15 @@ Sponsorship integrates with Okto's wallet infrastructure to automatically cover 
 1. Enable desired chains in your Okto dashboard
 2. Activate sponsorship for each chain
 3. Add native funds via airdrop or transfer to the sponsorship address.
-<CollapsibleCallout type="note" title="In case you are not able to find testnet tokens, you can fill out the form below.">
+<CollapsibleCallout type="note" title="In case you're unable to obtain testnet tokens, you can request them by filling out the form below.">
 
-<div style={{ width: '100%', maxWidth: '600px', margin: '0 auto' }}>
+<div style={{ width: '100%', maxWidth: '100%', margin: '0 auto' }}>
   <iframe
     id="typeform-widget"
     title="Troubleshooting Form"
     src="https://coindcx.typeform.com/to/oXtDR5xw"
     width="100%"
-    height="500px"
+    height="450px"
     frameBorder="0"
     allowFullScreen
     style={{ 

--- a/content/docs/developer-admin-dashboard/sponsorship.mdx
+++ b/content/docs/developer-admin-dashboard/sponsorship.mdx
@@ -37,7 +37,26 @@ Sponsorship integrates with Okto's wallet infrastructure to automatically cover 
 ## Steps to Set Up Sponsorship
 1. Enable desired chains in your Okto dashboard
 2. Activate sponsorship for each chain
-3. Add native funds via airdrop or transfer to the sponsorship address
+3. Add native funds via airdrop or transfer to the sponsorship address.
+<CollapsibleCallout type="note" title="In case you are not able to find testnet tokens, you can fill out the form below.">
+
+<div style={{ width: '100%', maxWidth: '600px', margin: '0 auto' }}>
+  <iframe
+    id="typeform-widget"
+    title="Troubleshooting Form"
+    src="https://coindcx.typeform.com/to/oXtDR5xw"
+    width="100%"
+    height="500px"
+    frameBorder="0"
+    allowFullScreen
+    style={{ 
+      border: 'none', 
+      borderRadius: '5px',
+      boxShadow: '0 2px 8px rgba(0,0,0,0.05)'
+    }}
+  ></iframe>
+</div>
+</CollapsibleCallout>
 4. Enable/disable sponsorship as needed
 
 <CollapsibleCallout type="tip" title="Sponsorship Necessity">

--- a/content/docs/nextjs-sdk/v2migration.mdx
+++ b/content/docs/nextjs-sdk/v2migration.mdx
@@ -8,6 +8,8 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 import { Callout } from 'fumadocs-ui/components/callout';
 import CollapsibleCallout from 'app/components/mdx/CollapsibleCallout';
+import ExternalLink from 'app/components/mdx/ExternalLink';
+
 
 This guide provides a detailed walkthrough for migrating a NextJS application from [Okto SDK V1](https://docs.okto.tech/docs/react-sdk) to [Okto SDK V2](https://docsv2.okto.tech/docs/nextjs-sdk).  
 
@@ -310,14 +312,14 @@ In V1, the AuthToken was a combination of the user login method and the client A
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`getWallets()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | [getAccount()](/docs/nextjs-sdk/getAccount)| - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
-| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-networks) | [`getChains(oktoClient)`](/docs/nextjs-sdk/getChains) | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
-| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | [`getTokens(oktoClient)`](/docs/nextjs-sdk/getTokens) | - Returns supported token list |
-| [`getPortfolio()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | [`getPortfolio(oktoClient)`](/docs/nextjs-sdk/getPortfolio) | - Now retrieves the user's aggregated portfolio data |
-| - | [`getPortfolioActivity(oktoClient)`](/docs/nextjs-sdk/getPortfolioActivity) | - Get user's portfolio activity |
-| - | [`getPortfolioNFT(oktoClient)`](/docs/nextjs-sdk/getPortfolioNFT) | - Get user's NFT portfolio |
-| - | [`getNftCollections(oktoClient)`](https://docsv2.okto.tech/docs/nextjs-sdk/getNftCollections) | - Retrieves NFT collection metadata |
-| [`orderHistory(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | [`getOrdersHistory(oktoClient, filters?)`](/docs/nextjs-sdk/getOrdersHistory) | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
+| [`getWallets()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | <ExternalLink href="/docs/nextjs-sdk/getAccount#get-account">`getAccount()`</ExternalLink> | - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
+| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-networks) | <ExternalLink href="/docs/nextjs-sdk/getChains#get-chains">`getChains(oktoClient)`</ExternalLink> | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
+| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | <ExternalLink href="/docs/nextjs-sdk/getTokens#get-tokens">`getTokens(oktoClient)`</ExternalLink> | - Returns supported token list |
+| [`getPortfolio()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | <ExternalLink href="/docs/nextjs-sdk/getPortfolio#get-portfolio">`getPortfolio(oktoClient)`</ExternalLink> | - Now retrieves the user's aggregated portfolio data |
+| - | <ExternalLink href="/docs/nextjs-sdk/getPortfolioActivity#get-portfolio-activity">`getPortfolioActivity(oktoClient)`</ExternalLink> | - Get user's portfolio activity |
+| - | <ExternalLink href="/docs/nextjs-sdk/getPortfolioNFT#get-portfolio-nft">`getPortfolioNFT(oktoClient)`</ExternalLink> | - Get user's NFT portfolio |
+| - | <ExternalLink href="https://docsv2.okto.tech/docs/nextjs-sdk/getNftCollections#get-nft-collections">`getNftCollections(oktoClient)`</ExternalLink> | - Retrieves NFT collection metadata |
+| [`orderHistory(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | <ExternalLink href="/docs/nextjs-sdk/getOrdersHistory#get-orders-history">`getOrdersHistory(oktoClient, filters?)`</ExternalLink> | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
 
 ### Intent Functions
 
@@ -325,16 +327,16 @@ All intents are available in both abstracted and detailed flows. In the detailed
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`transferTokens(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | [`tokenTransfer(oktoClient, data)`](/docs/nextjs-sdk/tokenTransfer) | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
-| [`transferNft(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | [`nftTransfer(oktoClient, data)`](/docs/nextjs-sdk/nftTransfer) | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks<br/> |
-| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | [`evmRawTransaction(oktoClient, data)`](/docs/nextjs-sdk/evmRawTransaction) | - Now creates a UserOp for executing raw EVM transactions.|
+| [`transferTokens(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | <ExternalLink href="/docs/nextjs-sdk/tokenTransfer#token-transfer">`tokenTransfer(oktoClient, data)`</ExternalLink> | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
+| [`transferNft(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | <ExternalLink href="/docs/nextjs-sdk/nftTransfer#nft-transfer">`nftTransfer(oktoClient, data)`</ExternalLink> | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks |
+| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | <ExternalLink href="/docs/nextjs-sdk/evmRawTransaction#evm-raw-transaction">`evmRawTransaction(oktoClient, data)`</ExternalLink> | - Now creates a UserOp for executing raw EVM transactions. |
 
 ### V2 Functions
 
 | Function | Description |
 |----------|-------------|
-| [`signUserOp(userop)`](/docs/nextjs-sdk/signUserOp) | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
-| [`executeUserOp(userop)`](/docs/nextjs-sdk/executeUserOp) | - Executes signed operations<br/>- Handles transaction bundling<br/>|
+| <ExternalLink href="/docs/nextjs-sdk/signUserOp#sign-userop">`signUserOp(userop)`</ExternalLink> | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
+| <ExternalLink href="/docs/nextjs-sdk/executeUserOp#execute-userop">`executeUserOp(userop)`</ExternalLink> | - Executes signed operations<br/>- Handles transaction bundling |
 
 <Callout title="Migration Support">
 For additional help:

--- a/content/docs/nextjs-sdk/v2migration.mdx
+++ b/content/docs/nextjs-sdk/v2migration.mdx
@@ -310,14 +310,14 @@ In V1, the AuthToken was a combination of the user login method and the client A
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`getWallets()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | [`getAccount()`](/docs/react-sdk/getAccount) | - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
-| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-networks) | [`getChains(oktoClient)`](/docs/react-sdk/getChains) | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
-| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | [`getTokens(oktoClient)`](/docs/react-sdk/getTokens) | - Returns supported token list |
-| [`getPortfolio()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | [`getPortfolio(oktoClient)`](/docs/react-sdk/getPortfolio) | - Now retrieves the user's aggregated portfolio data |
-| - | [`getPortfolioActivity(oktoClient)`](/docs/react-sdk/getPortfolioActivity) | - Get user's portfolio activity |
-| - | [`getPortfolioNFT(oktoClient)`](/docs/react-sdk/getPortfolioNFT) | - Get user's NFT portfolio |
-| - | [`getNftCollections(oktoClient)`](https://docsv2.okto.tech/docs/react-sdk/getNftCollections) | - Retrieves NFT collection metadata |
-| [`orderHistory(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | [`getOrdersHistory(oktoClient, filters?)`](/docs/react-sdk/getOrdersHistory) | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
+| [`getWallets()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | [getAccount()](/docs/nextjs-sdk/getAccount)| - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
+| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-networks) | [`getChains(oktoClient)`](/docs/nextjs-sdk/getChains) | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
+| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | [`getTokens(oktoClient)`](/docs/nextjs-sdk/getTokens) | - Returns supported token list |
+| [`getPortfolio()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | [`getPortfolio(oktoClient)`](/docs/nextjs-sdk/getPortfolio) | - Now retrieves the user's aggregated portfolio data |
+| - | [`getPortfolioActivity(oktoClient)`](/docs/nextjs-sdk/getPortfolioActivity) | - Get user's portfolio activity |
+| - | [`getPortfolioNFT(oktoClient)`](/docs/nextjs-sdk/getPortfolioNFT) | - Get user's NFT portfolio |
+| - | [`getNftCollections(oktoClient)`](https://docsv2.okto.tech/docs/nextjs-sdk/getNftCollections) | - Retrieves NFT collection metadata |
+| [`orderHistory(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | [`getOrdersHistory(oktoClient, filters?)`](/docs/nextjs-sdk/getOrdersHistory) | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
 
 ### Intent Functions
 
@@ -325,16 +325,16 @@ All intents are available in both abstracted and detailed flows. In the detailed
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`transferTokens(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | [`tokenTransfer(oktoClient, data)`](/docs/react-sdk/tokenTransfer) | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
-| [`transferNft(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | [`nftTransfer(oktoClient, data)`](/docs/react-sdk/nftTransfer) | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks<br/> |
-| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | [`evmRawTransaction(oktoClient, data)`](/docs/react-sdk/evmRawTransaction) | - Now creates a UserOp for executing raw EVM transactions.|
+| [`transferTokens(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | [`tokenTransfer(oktoClient, data)`](/docs/nextjs-sdk/tokenTransfer) | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
+| [`transferNft(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | [`nftTransfer(oktoClient, data)`](/docs/nextjs-sdk/nftTransfer) | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks<br/> |
+| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | [`evmRawTransaction(oktoClient, data)`](/docs/nextjs-sdk/evmRawTransaction) | - Now creates a UserOp for executing raw EVM transactions.|
 
 ### V2 Functions
 
 | Function | Description |
 |----------|-------------|
-| [`signUserOp(userop)`](/docs/react-sdk/signUserOp) | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
-| [`executeUserOp(userop)`](/docs/react-sdk/executeUserOp) | - Executes signed operations<br/>- Handles transaction bundling<br/>|
+| [`signUserOp(userop)`](/docs/nextjs-sdk/signUserOp) | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
+| [`executeUserOp(userop)`](/docs/nextjs-sdk/executeUserOp) | - Executes signed operations<br/>- Handles transaction bundling<br/>|
 
 <Callout title="Migration Support">
 For additional help:

--- a/content/docs/okto-layer/okto-token.mdx
+++ b/content/docs/okto-layer/okto-token.mdx
@@ -27,7 +27,7 @@ To request funds, please complete the form below:
     title="Troubleshooting Form"
     src="https://coindcx.typeform.com/to/oXtDR5xw"
     width="100%"
-    height="450px"
+    height="470px"
     frameBorder="0"
     allowFullScreen
     style={{ 

--- a/content/docs/okto-layer/okto-token.mdx
+++ b/content/docs/okto-layer/okto-token.mdx
@@ -18,15 +18,16 @@ For development and testing purposes, you can use Okto Credits (testnet $OKTO). 
 
 To obtain testnet $OKTO for development purposes, please refer to the [Okto Faucet Guide](/docs/developer-admin-dashboard/okto-faucet).
 
-### **Need Testnet/Mainnet Funds? Fill out the form below:**
+### **Need Testnet/Mainnet Funds?**
+To request funds, please complete the form below:
 
-<div style={{ width: '80%', maxWidth: '600px', margin: '0 auto' }}>
+<div style={{ width: '100%', maxWidth: '100%', margin: '0 auto' }}>
   <iframe
     id="typeform-widget"
     title="Troubleshooting Form"
     src="https://coindcx.typeform.com/to/oXtDR5xw"
     width="100%"
-    height="580px"
+    height="450px"
     frameBorder="0"
     allowFullScreen
     style={{ 

--- a/content/docs/react-native-sdk/v2migration.mdx
+++ b/content/docs/react-native-sdk/v2migration.mdx
@@ -34,7 +34,7 @@ Previously, Okto integration in React Native required one of the following metho
 - Manual Configuration using the React Native Community CLI. i.e. `npx @react-native-community/cli@latest init OktoApp`
 - Streamlined Okto React Native Setup for simplified integration. i.e. `npx create-okto-app@latest`
 
-Now as per the updated docs for React Native we have:
+With the latest updates to the React Native documentation, the recommended approach is now:
 ```bash
 npx create-expo-app@latest my-okto-app
 ```
@@ -271,14 +271,14 @@ In V1, the AuthToken was a combination of the user login method and the client A
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`getWallets()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | [`getAccount()`](/docs/react-native-sdk/getAccount) | - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
-| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-native-sdk/chains-tokens/supported-networks#get-all-supported-networks) | [`getChains(oktoClient)`](/docs/react-native-sdk/getChains) | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
-| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-native-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | [`getTokens(oktoClient)`](/docs/react-native-sdk/getTokens) | - Returns supported token list |
-| [`getPortfolio()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | [`getPortfolio(oktoClient)`](/docs/react-native-sdk/getPortfolio) | - Now retrieves the user's aggregated portfolio data |
-| - | [`getPortfolioActivity(oktoClient)`](/docs/react-native-sdk/getPortfolioActivity) | - Get user's portfolio activity |
-| - | [`getPortfolioNFT(oktoClient)`](/docs/react-native-sdk/getPortfolioNFT) | - Get user's NFT portfolio |
-| - | [`getNftCollections(oktoClient)`](https://docsv2.okto.tech/docs/react-native-sdk/getNftCollections) | - Retrieves NFT collection metadata |
-| [`orderHistory(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | [`getOrdersHistory(oktoClient, filters?)`](/docs/react-native-sdk/getOrderHistory) | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
+| [`getWallets()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | <ExternalLink href="/docs/react-native-sdk/getAccount">`getAccount()`</ExternalLink> | - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
+| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-native-sdk/chains-tokens/supported-networks#get-all-supported-networks) | <ExternalLink href="/docs/react-native-sdk/getChains">`getChains(oktoClient)`</ExternalLink> | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
+| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-native-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | <ExternalLink href="/docs/react-native-sdk/getTokens">`getTokens(oktoClient)`</ExternalLink> | - Returns supported token list |
+| [`getPortfolio()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | <ExternalLink href="/docs/react-native-sdk/getPortfolio">`getPortfolio(oktoClient)`</ExternalLink> | - Now retrieves the user's aggregated portfolio data |
+| - | <ExternalLink href="/docs/react-native-sdk/getPortfolioActivity">`getPortfolioActivity(oktoClient)`</ExternalLink> | - Get user's portfolio activity |
+| - | <ExternalLink href="/docs/react-native-sdk/getPortfolioNFT">`getPortfolioNFT(oktoClient)`</ExternalLink> | - Get user's NFT portfolio |
+| - | <ExternalLink href="https://docsv2.okto.tech/docs/react-native-sdk/getNftCollections">`getNftCollections(oktoClient)`</ExternalLink> | - Retrieves NFT collection metadata |
+| [`orderHistory(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | <ExternalLink href="/docs/react-native-sdk/getOrderHistory">`getOrdersHistory(oktoClient, filters?)`</ExternalLink> | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
 
 ### Intent Functions
 
@@ -286,20 +286,21 @@ All intents are available in both abstracted and detailed flows. In the detailed
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`transferTokens(data)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | [`tokenTransfer(oktoClient, data)`](/docs/react-native-sdk/tokenTransfer) | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
-| [`transferNft(data)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | [`nftTransfer(oktoClient, data)`](/docs/react-native-sdk/nftTransfer) | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks<br/> |
-| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | [`evmRawTransaction(oktoClient, data)`](/docs/react-native-sdk/evmRawTransaction) | - Now creates a UserOp for executing raw EVM transactions.|
+| [`transferTokens(data)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | <ExternalLink href="/docs/react-native-sdk/tokenTransfer">`tokenTransfer(oktoClient, data)`</ExternalLink> | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
+| [`transferNft(data)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | <ExternalLink href="/docs/react-native-sdk/nftTransfer">`nftTransfer(oktoClient, data)`</ExternalLink> | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks |
+| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | <ExternalLink href="/docs/react-native-sdk/evmRawTransaction">`evmRawTransaction(oktoClient, data)`</ExternalLink> | - Now creates a UserOp for executing raw EVM transactions. |
+
 
 ### V2 Functions
 
 | Function | Description |
 |----------|-------------|
-| [`signUserOp(userop)`](/docs/react-native-sdk/signUserOp) | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
-| [`executeUserOp(userop)`](/docs/react-native-sdk/executeUserOp) | - Executes signed operations<br/>- Handles transaction bundling<br/>|
+| <ExternalLink href="/docs/react-native-sdk/signUserOp">`signUserOp(userop)`</ExternalLink> | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
+| <ExternalLink href="/docs/react-native-sdk/executeUserOp">`executeUserOp(userop)`</ExternalLink> | - Executes signed operations<br/>- Handles transaction bundling |
 
 <Callout title="Migration Support">
 For additional help:
-- [Okto V1 Docs for React](https://docs.okto.tech/docs/react-sdk)
-- [Okto V2 Docs for React](https://docsV2.okto.tech/docs/react-sdk/quickstart/new-okto-react-setup)
+- [Okto V1 Docs for React Native](https://docs.okto.tech/docs/react-native-sdk)
+- [Okto V2 Docs for React Native](https://docsV2.okto.tech/docs/react-native-sdk/)
 - [V2 Developer Dashboard](/docs/developer-admin-dashboard)
 </Callout>

--- a/content/docs/react-native-sdk/v2migration.mdx
+++ b/content/docs/react-native-sdk/v2migration.mdx
@@ -167,17 +167,17 @@ In V2, authentication remains backward-compatible with V1.
 <Tab value="Updated Implementation">
 ```tsx
 // Using Google OAuth
-async function handleGoogleLogin(credentialResponse: any) {
+const handleAuthenticate = async (idToken: string) => {
     try {
-        const user = await oktoClient.loginUsingOAuth({
-            idToken: credentialResponse.credential,
-            provider: "google",
+        const response = await oktoClient.loginUsingOAuth({
+            idToken: idToken,
+            provider: 'google',
         });
-        console.log("Login successful:", user);
+        console.log("Authenticated with Okto", response);
     } catch (error) {
-        console.error("Login failed:", error);
+        console.error("Authentication failed:", error);
     }
-}
+};
 ```
 </Tab>
 </div>

--- a/content/docs/react-native-sdk/v2migration.mdx
+++ b/content/docs/react-native-sdk/v2migration.mdx
@@ -24,15 +24,20 @@ This guide provides a detailed walkthrough for migrating your React Native appli
 | Wallet Management | Automated wallet creation across all enabled chains |
 | Package Structure | Migration to scoped packages under @okto_web3 namespace |
 
-## Migration Steps
-
-Previously, Okto integration in React Native required one of the following methods:
-- Manual Configuration using the React Native Community CLI.
-- Streamlined Okto React Native Setup for simplified integration.
-With Okto SDK V2, an optimized Expo setup is now available, enhancing the onboarding process.
 <Callout title="Note">
 This guide assumes that you have already set up a fully functional react dapp using Okto SDK V1.
 </Callout>
+
+## Migration Steps
+
+Previously, Okto integration in React Native required one of the following methods:
+- Manual Configuration using the React Native Community CLI. i.e. `npx @react-native-community/cli@latest init OktoApp`
+- Streamlined Okto React Native Setup for simplified integration. i.e. `npx create-okto-app@latest`
+
+Now as per the updated docs for React Native we have:
+```bash
+npx create-expo-app@latest my-okto-app
+```
 
 ### 1. Installing Dependencies
 
@@ -42,17 +47,17 @@ Previously, it was `okto-sdk-react`; it has now been updated to:
 <Tabs items={['npm','pnpm', 'yarn']} defaultValue="npm">
 <Tab value="npm">
 ```bash
-npm i @okto_web3/react-native-sdk@latest expo-auth-session expo-web-browser
+npm i @okto_web3/react-native-sdk@latest expo-auth-session expo-web-browser react-native-mmkv
 ```
 </Tab>
 <Tab value="pnpm">
 ```bash
-pnpm add @okto_web3/react-native-sdk@latest expo-auth-session expo-web-browser 
+pnpm add @okto_web3/react-native-sdk@latest expo-auth-session expo-web-browser react-native-mmkv
 ```
 </Tab>
 <Tab value="yarn">
 ```bash
-yarn add @okto_web3/react-native-sdk@latest expo-auth-session expo-web-browser
+yarn add @okto_web3/react-native-sdk@latest expo-auth-session expo-web-browser react-native-mmkv
 ```
 </Tab>
 </Tabs>
@@ -67,9 +72,6 @@ In Okto V1, only one environment variable was needed: `OKTO_CLIENT_API_KEY`. How
 ```env
 CLIENT_PRIVATE_KEY="YOUR_CLIENT_PRIVATE_KEY"
 CLIENT_SWA="YOUR_CLIENT_SWA"
-
-# Optional - Required only for Google Sign-In
-GOOGLE_CLIENT_ID="YOUR_GOOGLE_CLIENT_ID"
 ```
 </Tab>
 </div>
@@ -102,15 +104,15 @@ In V1, the provider required `OKTO_CLIENT_API_KEY` and `buildType` as parameters
 <div>
 <Tab value="Updated Implementation" >
 ```tsx 
-import { OktoProvider } from '@okto_web3/react-native-sdk';
+import { Hash, Hex, OktoProvider } from '@okto_web3/react-native-sdk';
 import { ThemeProvider } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
  
 const config = {
     environment: "sandbox",
-    clientPrivateKey: "YOUR_CLIENT_PRIVATE_KEY",  // Replace with your actual private key
-    clientSWA: "YOUR_CLIENT_SWA",             // Replace with your actual SWA
+    clientPrivateKey: "YOUR_CLIENT_PRIVATE_KEY" as Hash,  // Replace with your actual private key
+    clientSWA: "YOUR_CLIENT_SWA" as Hex,             // Replace with your actual SWA
 };
  
 export default function RootLayout() {
@@ -132,10 +134,6 @@ export default function RootLayout() {
 <div className="no-copy-code">
 <Tab value="Old Implementation"> 
 ```tsx
-/**
-* @format
-*/
-
 import { AppRegistry } from 'react-native';
 import App from './src/App';
 import { name as appName } from './app.json';
@@ -159,7 +157,7 @@ AppRegistry.registerComponent(appName, () => Root);
 
 ### 5. Authentication Implementation
 
-In V1, Okto supports multiple authentication methods, including [`Google-Auth (GAuth)`](https://docs.okto.tech/docs/react-sdk/authenticate-users/google-oauth/auth-user-via-code#authenticate-a-user), [`email-OTP`](https://docs.okto.tech/docs/react-sdk/authenticate-users/email-otp/auth-user-via-email), [`phone-OTP`](https://docs.okto.tech/docs/react-sdk/authenticate-users/phone-otp/auth-user-via-phone), and [`JWT-custom-auth`](https://docs.okto.tech/docs/react-sdk/authenticate-users/jwt-closed-loop/learn). Upon successful authentication, Okto generates an AuthToken, which is used for delegated access.
+In V1, Okto supports multiple authentication methods, including [`Google-Auth (GAuth)`](https://docs.okto.tech/docs/react-native-sdk/authenticate-users/google-oauth/auth-user-via-code#authenticate-a-user), [`email-OTP`](https://docs.okto.tech/docs/react-native-sdk/authenticate-users/email-otp/auth-user-via-email), and [`phone-OTP`](https://docs.okto.tech/docs/react-native-sdk/authenticate-users/phone-otp/auth-user-via-phone). Upon successful authentication, Okto generates an AuthToken, which is used for delegated access.
 
 In V2, authentication remains backward-compatible with V1.
 - **Using Google Authentication (Google OAuth)**; V2 continues to support direct authentication with Google OAuth, maintaining seamless integration with Google's trusted authentication infrastructure within the Okto React SDK.
@@ -252,7 +250,7 @@ authenticate(idToken, (result, error) => {
 
 #### **Wallet Creation in V2**
 
-In V1, wallets had to be manually created using [`createWallet()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/setup-embedded-wallets/create-embedded-wallets#create-a-new-wallet-for-current-user). In V2, after successful authentication:
+In V1, wallets had to be manually created using [`createWallet()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/setup-embedded-wallets/create-embedded-wallets#create-a-new-wallet-for-current-user). In V2, after successful authentication:
 - A session is created for the user and client, with a default validity of 7 days. However, this duration can be customized as needed
 - Wallets are automatically retrieved for the user or created if none exist
 - Users automatically have wallets in all enabled chains of the client
@@ -273,14 +271,14 @@ In V1, the AuthToken was a combination of the user login method and the client A
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`getWallets()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | [`getAccount()`](/docs/react-sdk/getAccount) | - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
-| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-networks) | [`getChains(oktoClient)`](/docs/react-sdk/getChains) | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
-| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | [`getTokens(oktoClient)`](/docs/react-sdk/getTokens) | - Returns supported token list |
-| [`getPortfolio()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | [`getPortfolio(oktoClient)`](/docs/react-sdk/getPortfolio) | - Now retrieves the user's aggregated portfolio data |
-| - | [`getPortfolioActivity(oktoClient)`](/docs/react-sdk/getPortfolioActivity) | - Get user's portfolio activity |
-| - | [`getPortfolioNFT(oktoClient)`](/docs/react-sdk/getPortfolioNFT) | - Get user's NFT portfolio |
-| - | [`getNftCollections(oktoClient)`](https://docsv2.okto.tech/docs/react-sdk/getNftCollections) | - Retrieves NFT collection metadata |
-| [`orderHistory(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | [`getOrdersHistory(oktoClient, filters?)`](/docs/react-sdk/getOrdersHistory) | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
+| [`getWallets()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | [`getAccount()`](/docs/react-native-sdk/getAccount) | - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
+| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-native-sdk/chains-tokens/supported-networks#get-all-supported-networks) | [`getChains(oktoClient)`](/docs/react-native-sdk/getChains) | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
+| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-native-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | [`getTokens(oktoClient)`](/docs/react-native-sdk/getTokens) | - Returns supported token list |
+| [`getPortfolio()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | [`getPortfolio(oktoClient)`](/docs/react-native-sdk/getPortfolio) | - Now retrieves the user's aggregated portfolio data |
+| - | [`getPortfolioActivity(oktoClient)`](/docs/react-native-sdk/getPortfolioActivity) | - Get user's portfolio activity |
+| - | [`getPortfolioNFT(oktoClient)`](/docs/react-native-sdk/getPortfolioNFT) | - Get user's NFT portfolio |
+| - | [`getNftCollections(oktoClient)`](https://docsv2.okto.tech/docs/react-native-sdk/getNftCollections) | - Retrieves NFT collection metadata |
+| [`orderHistory(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | [`getOrdersHistory(oktoClient, filters?)`](/docs/react-native-sdk/getOrderHistory) | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
 
 ### Intent Functions
 
@@ -288,16 +286,16 @@ All intents are available in both abstracted and detailed flows. In the detailed
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`transferTokens(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | [`tokenTransfer(oktoClient, data)`](/docs/react-sdk/tokenTransfer) | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
-| [`transferNft(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | [`nftTransfer(oktoClient, data)`](/docs/react-sdk/nftTransfer) | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks<br/> |
-| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | [`evmRawTransaction(oktoClient, data)`](/docs/react-sdk/evmRawTransaction) | - Now creates a UserOp for executing raw EVM transactions.|
+| [`transferTokens(data)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | [`tokenTransfer(oktoClient, data)`](/docs/react-native-sdk/tokenTransfer) | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
+| [`transferNft(data)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | [`nftTransfer(oktoClient, data)`](/docs/react-native-sdk/nftTransfer) | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks<br/> |
+| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | [`evmRawTransaction(oktoClient, data)`](/docs/react-native-sdk/evmRawTransaction) | - Now creates a UserOp for executing raw EVM transactions.|
 
 ### V2 Functions
 
 | Function | Description |
 |----------|-------------|
-| [`signUserOp(userop)`](/docs/react-sdk/signUserOp) | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
-| [`executeUserOp(userop)`](/docs/react-sdk/executeUserOp) | - Executes signed operations<br/>- Handles transaction bundling<br/>|
+| [`signUserOp(userop)`](/docs/react-native-sdk/signUserOp) | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
+| [`executeUserOp(userop)`](/docs/react-native-sdk/executeUserOp) | - Executes signed operations<br/>- Handles transaction bundling<br/>|
 
 <Callout title="Migration Support">
 For additional help:

--- a/content/docs/react-native-sdk/v2migration.mdx
+++ b/content/docs/react-native-sdk/v2migration.mdx
@@ -271,14 +271,14 @@ In V1, the AuthToken was a combination of the user login method and the client A
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`getWallets()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | <ExternalLink href="/docs/react-native-sdk/getAccount">`getAccount()`</ExternalLink> | - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
-| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-native-sdk/chains-tokens/supported-networks#get-all-supported-networks) | <ExternalLink href="/docs/react-native-sdk/getChains">`getChains(oktoClient)`</ExternalLink> | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
-| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-native-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | <ExternalLink href="/docs/react-native-sdk/getTokens">`getTokens(oktoClient)`</ExternalLink> | - Returns supported token list |
-| [`getPortfolio()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | <ExternalLink href="/docs/react-native-sdk/getPortfolio">`getPortfolio(oktoClient)`</ExternalLink> | - Now retrieves the user's aggregated portfolio data |
-| - | <ExternalLink href="/docs/react-native-sdk/getPortfolioActivity">`getPortfolioActivity(oktoClient)`</ExternalLink> | - Get user's portfolio activity |
-| - | <ExternalLink href="/docs/react-native-sdk/getPortfolioNFT">`getPortfolioNFT(oktoClient)`</ExternalLink> | - Get user's NFT portfolio |
-| - | <ExternalLink href="https://docsv2.okto.tech/docs/react-native-sdk/getNftCollections">`getNftCollections(oktoClient)`</ExternalLink> | - Retrieves NFT collection metadata |
-| [`orderHistory(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | <ExternalLink href="/docs/react-native-sdk/getOrderHistory">`getOrdersHistory(oktoClient, filters?)`</ExternalLink> | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
+| [`getWallets()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | <ExternalLink href="/docs/react-native-sdk/getAccount#get-account">`getAccount()`</ExternalLink> | - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
+| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-native-sdk/chains-tokens/supported-networks#get-all-supported-networks) | <ExternalLink href="/docs/react-native-sdk/getChains#get-chains">`getChains(oktoClient)`</ExternalLink> | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
+| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-native-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | <ExternalLink href="/docs/react-native-sdk/getTokens#get-tokens">`getTokens(oktoClient)`</ExternalLink> | - Returns supported token list |
+| [`getPortfolio()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | <ExternalLink href="/docs/react-native-sdk/getPortfolio#get-portfolio">`getPortfolio(oktoClient)`</ExternalLink> | - Now retrieves the user's aggregated portfolio data |
+| - | <ExternalLink href="/docs/react-native-sdk/getPortfolioActivity#get-portfolio-activity">`getPortfolioActivity(oktoClient)`</ExternalLink> | - Get user's portfolio activity |
+| - | <ExternalLink href="/docs/react-native-sdk/getPortfolioNFT#get-portfolio-nft">`getPortfolioNFT(oktoClient)`</ExternalLink> | - Get user's NFT portfolio |
+| - | <ExternalLink href="https://docsv2.okto.tech/docs/react-native-sdk/getNftCollections#get-nft-collections">`getNftCollections(oktoClient)`</ExternalLink> | - Retrieves NFT collection metadata |
+| [`orderHistory(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | <ExternalLink href="/docs/react-native-sdk/getOrderHistory#get-orders-history">`getOrdersHistory(oktoClient, filters?)`</ExternalLink> | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
 
 ### Intent Functions
 
@@ -286,17 +286,16 @@ All intents are available in both abstracted and detailed flows. In the detailed
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`transferTokens(data)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | <ExternalLink href="/docs/react-native-sdk/tokenTransfer">`tokenTransfer(oktoClient, data)`</ExternalLink> | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
-| [`transferNft(data)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | <ExternalLink href="/docs/react-native-sdk/nftTransfer">`nftTransfer(oktoClient, data)`</ExternalLink> | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks |
-| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | <ExternalLink href="/docs/react-native-sdk/evmRawTransaction">`evmRawTransaction(oktoClient, data)`</ExternalLink> | - Now creates a UserOp for executing raw EVM transactions. |
-
+| [`transferTokens(data)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | <ExternalLink href="/docs/react-native-sdk/tokenTransfer#token-transfer">`tokenTransfer(oktoClient, data)`</ExternalLink> | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
+| [`transferNft(data)`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | <ExternalLink href="/docs/react-native-sdk/nftTransfer#nft-transfer">`nftTransfer(oktoClient, data)`</ExternalLink> | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks |
+| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | <ExternalLink href="/docs/react-native-sdk/evmRawTransaction#evm-raw-transaction">`evmRawTransaction(oktoClient, data)`</ExternalLink> | - Now creates a UserOp for executing raw EVM transactions. |
 
 ### V2 Functions
 
 | Function | Description |
 |----------|-------------|
-| <ExternalLink href="/docs/react-native-sdk/signUserOp">`signUserOp(userop)`</ExternalLink> | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
-| <ExternalLink href="/docs/react-native-sdk/executeUserOp">`executeUserOp(userop)`</ExternalLink> | - Executes signed operations<br/>- Handles transaction bundling |
+| <ExternalLink href="/docs/react-native-sdk/signUserOp#sign-userop">`signUserOp(userop)`</ExternalLink> | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
+| <ExternalLink href="/docs/react-native-sdk/executeUserOp#execute-userop">`executeUserOp(userop)`</ExternalLink> | - Executes signed operations<br/>- Handles transaction bundling |
 
 <Callout title="Migration Support">
 For additional help:

--- a/content/docs/react-sdk/v2migration.mdx
+++ b/content/docs/react-sdk/v2migration.mdx
@@ -284,8 +284,6 @@ In V1, the AuthToken was a combination of the user login method and the client A
 | - | <ExternalLink href="https://docsv2.okto.tech/docs/react-sdk/getNftCollections#get-nft-collections">`getNftCollections(oktoClient)`</ExternalLink> | - Retrieves NFT collection metadata |
 | [`orderHistory(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | <ExternalLink href="/docs/react-sdk/getOrdersHistory#get-orders-history">`getOrdersHistory(oktoClient, filters?)`</ExternalLink> | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
 
----
-
 ### Intent Functions
 
 All intents are available in both abstracted and detailed flows. In the detailed flow, intents can be converted into a user operation (UserOp), signed, and executed on the Okto chain as separate calls. In the abstracted flow, these three steps are combined into a single call for a more seamless experience.
@@ -295,8 +293,6 @@ All intents are available in both abstracted and detailed flows. In the detailed
 | [`transferTokens(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | <ExternalLink href="/docs/react-sdk/tokenTransfer#token-transfer">`tokenTransfer(oktoClient, data)`</ExternalLink> | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
 | [`transferNft(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | <ExternalLink href="/docs/react-sdk/nftTransfer#nft-transfer">`nftTransfer(oktoClient, data)`</ExternalLink> | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks |
 | [`executeRawTransaction()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | <ExternalLink href="/docs/react-sdk/evmRawTransaction#evm-raw-transaction">`evmRawTransaction(oktoClient, data)`</ExternalLink> | - Now creates a UserOp for executing raw EVM transactions. |
-
----
 
 ### V2 Functions
 

--- a/content/docs/react-sdk/v2migration.mdx
+++ b/content/docs/react-sdk/v2migration.mdx
@@ -275,14 +275,16 @@ In V1, the AuthToken was a combination of the user login method and the client A
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`getWallets()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | [`getAccount()`](/docs/react-sdk/getAccount) | - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
-| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-networks) | [`getChains(oktoClient)`](/docs/react-sdk/getChains) | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
-| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | [`getTokens(oktoClient)`](/docs/react-sdk/getTokens) | - Returns supported token list |
-| [`getPortfolio()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | [`getPortfolio(oktoClient)`](/docs/react-sdk/getPortfolio) | - Now retrieves the user's aggregated portfolio data |
-| - | [`getPortfolioActivity(oktoClient)`](/docs/react-sdk/getPortfolioActivity) | - Get user's portfolio activity |
-| - | [`getPortfolioNFT(oktoClient)`](/docs/react-sdk/getPortfolioNFT) | - Get user's NFT portfolio |
-| - | [`getNftCollections(oktoClient)`](https://docsv2.okto.tech/docs/react-sdk/getNftCollections) | - Retrieves NFT collection metadata |
-| [`orderHistory(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | [`getOrdersHistory(oktoClient, filters?)`](/docs/react-sdk/getOrdersHistory) | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
+| [`getWallets()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-embedded-wallet-details) | <ExternalLink href="/docs/react-sdk/getAccount#get-account">`getAccount()`</ExternalLink> | - Now returns enhanced wallet details<br/>- Includes network symbol and comprehensive chain data |
+| [`getSupportedNetworks()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-networks) | <ExternalLink href="/docs/react-sdk/getChains#get-chains">`getChains(oktoClient)`</ExternalLink> | - Renamed for clarity<br/>- Retrieves the list of all blockchain networks supported by Okto |
+| [`getSupportedTokens()`](https://docs.okto.tech/docs/react-sdk/chains-tokens/supported-networks#get-all-supported-tokens) | <ExternalLink href="/docs/react-sdk/getTokens#get-tokens">`getTokens(oktoClient)`</ExternalLink> | - Returns supported token list |
+| [`getPortfolio()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/get-user-balance-portfolio) | <ExternalLink href="/docs/react-sdk/getPortfolio#get-portfolio">`getPortfolio(oktoClient)`</ExternalLink> | - Now retrieves the user's aggregated portfolio data |
+| - | <ExternalLink href="/docs/react-sdk/getPortfolioActivity#get-portfolio-activity">`getPortfolioActivity(oktoClient)`</ExternalLink> | - Get user's portfolio activity |
+| - | <ExternalLink href="/docs/react-sdk/getPortfolioNFT#get-portfolio-nft">`getPortfolioNFT(oktoClient)`</ExternalLink> | - Get user's NFT portfolio |
+| - | <ExternalLink href="https://docsv2.okto.tech/docs/react-sdk/getNftCollections#get-nft-collections">`getNftCollections(oktoClient)`</ExternalLink> | - Retrieves NFT collection metadata |
+| [`orderHistory(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | <ExternalLink href="/docs/react-sdk/getOrdersHistory#get-orders-history">`getOrdersHistory(oktoClient, filters?)`</ExternalLink> | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
+
+---
 
 ### Intent Functions
 
@@ -290,16 +292,18 @@ All intents are available in both abstracted and detailed flows. In the detailed
 
 | V1 Function | V2 Function | Changes |
 |------------|-------------|----------|
-| [`transferTokens(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | [`tokenTransfer(oktoClient, data)`](/docs/react-sdk/tokenTransfer) | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
-| [`transferNft(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | [`nftTransfer(oktoClient, data)`](/docs/react-sdk/nftTransfer) | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks<br/> |
-| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | [`evmRawTransaction(oktoClient, data)`](/docs/react-sdk/evmRawTransaction) | - Now creates a UserOp for executing raw EVM transactions.|
+| [`transferTokens(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#transfer-tokens) | <ExternalLink href="/docs/react-sdk/tokenTransfer#token-transfer">`tokenTransfer(oktoClient, data)`</ExternalLink> | - Switched to UserOp-based transfer model<br/>- Added transaction simulation<br/>- Improved gas optimization options |
+| [`transferNft(data)`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#transfer-nfts) | <ExternalLink href="/docs/react-sdk/nftTransfer#nft-transfer">`nftTransfer(oktoClient, data)`</ExternalLink> | - Converted to UserOp-based transfer model<br/>- Consolidated multiple NFT functions into one<br/>- Added chain compatibility checks |
+| [`executeRawTransaction()`](https://docs.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#execute-raw-transaction) | <ExternalLink href="/docs/react-sdk/evmRawTransaction#evm-raw-transaction">`evmRawTransaction(oktoClient, data)`</ExternalLink> | - Now creates a UserOp for executing raw EVM transactions. |
+
+---
 
 ### V2 Functions
 
 | Function | Description |
 |----------|-------------|
-| [`signUserOp(userop)`](/docs/react-sdk/signUserOp) | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
-| [`executeUserOp(userop)`](/docs/react-sdk/executeUserOp) | - Executes signed operations<br/>- Handles transaction bundling<br/>|
+| <ExternalLink href="/docs/react-sdk/signUserOp#sign-userop">`signUserOp(userop)`</ExternalLink> | - Signs user operations<br/>- Validates operation parameters<br/>- Includes policy checks |
+| <ExternalLink href="/docs/react-sdk/executeUserOp#execute-userop">`executeUserOp(userop)`</ExternalLink> | - Executes signed operations<br/>- Handles transaction bundling |
 
 <Callout title="Migration Support">
 For additional help:

--- a/content/docs/supported-chains.mdx
+++ b/content/docs/supported-chains.mdx
@@ -29,7 +29,7 @@ To request funds, please complete the form below:
     title="Troubleshooting Form"
     src="https://coindcx.typeform.com/to/oXtDR5xw"
     width="100%"
-    height="450px"
+    height="470px"
     frameBorder="0"
     allowFullScreen
     style={{ 

--- a/content/docs/supported-chains.mdx
+++ b/content/docs/supported-chains.mdx
@@ -2,13 +2,13 @@
 title: Supported Chains & Tokens
 full: false
 ---
-
-Overview of supported chains, wallet structure, testnet availability, and token whitelisting in Okto's ecosystem. These chains and tokens can be enabled from the [**Okto Dashboard**](https://dashboard.okto.tech/wallet-controls). Learn how [here](docs/developer-admin-dashboard/wallet-control)
-
 import { Callout } from 'fumadocs-ui/components/callout';
 import SupportedChainCard from "app/components/mdx/SupportedChainCard";
 import ChainNavigationCard from "app/components/mdx/ChainNavigationCard";
 import ChainDescriptionTable from "app/components/mdx/ChainDescriptionTable";
+import ExternalLink from 'app/components/mdx/ExternalLink';
+
+Overview of supported chains, wallet structure, testnet availability, and token whitelisting in Okto's ecosystem. These chains and tokens can be enabled from the [**Okto Dashboard**](https://dashboard.okto.tech/wallet-controls). Learn how <ExternalLink href="/developer-admin-dashboard/wallet-control">**here**</ExternalLink>.
 
 {/* <ChainNavigationCard /> */}
 

--- a/content/docs/supported-chains.mdx
+++ b/content/docs/supported-chains.mdx
@@ -21,16 +21,15 @@ Overview of supported chains, wallet structure, testnet availability, and token 
 </Callout>
 
 ### **Need Testnet/Mainnet Funds?**
+To request funds, please complete the form below:
 
-Fill out the form below:
-
-<div style={{ width: '100%', maxWidth: '600px', margin: '0 auto' }}>
+<div style={{ width: '100%', maxWidth: '100%', margin: '0 auto' }}>
   <iframe
     id="typeform-widget"
     title="Troubleshooting Form"
     src="https://coindcx.typeform.com/to/oXtDR5xw"
     width="100%"
-    height="500px"
+    height="450px"
     frameBorder="0"
     allowFullScreen
     style={{ 

--- a/content/docs/supported-chains.mdx
+++ b/content/docs/supported-chains.mdx
@@ -3,32 +3,34 @@ title: Supported Chains & Tokens
 full: false
 ---
 
-Overview of supported chains, wallet structure, testnet availability, and token whitelisting in Okto's ecosystem. These chains and tokens can be enabled from the [**Okto Dashboard**](https://dashboard.okto.tech/wallet-controls).
+Overview of supported chains, wallet structure, testnet availability, and token whitelisting in Okto's ecosystem. These chains and tokens can be enabled from the [**Okto Dashboard**](https://dashboard.okto.tech/wallet-controls). Learn how [here](docs/developer-admin-dashboard/wallet-control)
 
 import { Callout } from 'fumadocs-ui/components/callout';
 import SupportedChainCard from "app/components/mdx/SupportedChainCard";
 import ChainNavigationCard from "app/components/mdx/ChainNavigationCard";
 import ChainDescriptionTable from "app/components/mdx/ChainDescriptionTable";
 
-<ChainNavigationCard />
+{/* <ChainNavigationCard /> */}
 
 ## Overview
 
 <ChainDescriptionTable />
 
-<Callout title="What is Type?">
+<Callout title="What is Type*?">
 **Type** refers to the family of chains or ecosystems a blockchain belongs to. For example, the EVM ecosystem includes all chains that run EVM-compatible nodes, sharing similar consensus mechanisms and transaction processing methods. Other ecosystems include Solana, Aptos, Bitcoin, and Cosmos, each with distinct approaches to transaction payload creation and processing. Understanding a chain’s type is essential for constructing the appropriate payloads when interacting with that blockchain.
 </Callout>
 
-### **Need Testnet/Mainnet Funds? Fill out the form below:**
+### **Need Testnet/Mainnet Funds?**
 
-<div style={{ width: '80%', maxWidth: '600px', margin: '0 auto' }}>
+Fill out the form below:
+
+<div style={{ width: '100%', maxWidth: '600px', margin: '0 auto' }}>
   <iframe
     id="typeform-widget"
     title="Troubleshooting Form"
     src="https://coindcx.typeform.com/to/oXtDR5xw"
     width="100%"
-    height="580px"
+    height="500px"
     frameBorder="0"
     allowFullScreen
     style={{ 


### PR DESCRIPTION
Changes addressed in this PR:

- Add migration guide for `react-native-sdk`
- Fix the links for all the functions in the migration guide of `react-sdk`, `react-native-sdk` and `nextjs-sdk`
- Fix the "**Request Funds**" Typeform in all the respective pages
- Link the "**Learn now here**" to the proper doc in the sponsorship section