### PR TITLE
Add message signing references for all sdks & improve explorer function pages for typescript sdk

### DIFF
--- a/content/docs/nextjs-sdk/index.mdx
+++ b/content/docs/nextjs-sdk/index.mdx
@@ -647,6 +647,15 @@ Congratulations! You have successfully integrated the Okto SDK with your Next.js
 | `const orders = await getOrdersHistory(oktoClient);` | Get transaction order history | <ExternalLink href="/docs/nextjs-sdk/getOrdersHistory">Method Overview</ExternalLink> |
 | `const collections = await getNftCollections(oktoClient);` | Get NFT collections | <ExternalLink href="/docs/nextjs-sdk/getNFTCollections">Method Overview</ExternalLink> |
 
+### Message Signing
+
+Enables the creation of signatures for messages or object data. The signing process is initiated through the OktoClient instance.
+
+| Command | Description | Documentation |
+|---------|-------------|---------------|
+| `const signature = await oktoClient.signMessage(message);` | Signs messages following the EIP191 standard | <ExternalLink href="/docs/nextjs-sdk/signMessage">Method Overview</ExternalLink> |
+| `const signature = await oktoClient.signTypedData(data);` | Signs typed data following the EIP712 standard | <ExternalLink href="/docs/nextjs-sdk/signTypedData">Method Overview</ExternalLink> |
+
 ### User Operations (Intents)
 
 Intents are pre-built action templates within the Okto SDK that simplify common Web3 tasks. They provide one-liner functions for complex blockchain interactions.

--- a/content/docs/nextjs-sdk/overview.mdx
+++ b/content/docs/nextjs-sdk/overview.mdx
@@ -68,7 +68,7 @@ Kickstart your project by following our [Quickstart Guide](/docs/nextjs-sdk). Th
     className="h-25"
     icon={<IoConstructOutline size={"1.5rem"} />}
     title="Usage & Features"
-    subtitle="Explore hooks, explorer functions, and intent operations"
+    subtitle="Explore hooks, explorer functions, message signing and intent operations"
     link="/docs/nextjs-sdk/usage-overview"
   />
   <TechnologyCard

--- a/content/docs/nextjs-sdk/usage-overview.mdx
+++ b/content/docs/nextjs-sdk/usage-overview.mdx
@@ -14,7 +14,8 @@ import {
   IoServerOutline,
   IoAppsOutline,
   IoListOutline,
-  IoRocketOutline
+  IoRocketOutline,
+  IoLockClosedOutline
 } from "react-icons/io5";
 
 The Okto React SDK provides a comprehensive set of tools and hooks for integrating blockchain functionality into your React applications. This guide will help you understand the main components and features available in the SDK.
@@ -119,6 +120,24 @@ The Okto React SDK provides a comprehensive set of tools and hooks for integrati
     title="getTokens"
     subtitle="List available tokens and their details"
     link="/docs/nextjs-sdk/getTokens"
+  />
+</div>
+
+## Message Signing
+
+<div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-6 lg:gap-8">
+  <TechnologyCard
+    icon={<IoLockClosedOutline size={"1.5rem"} />}
+    title="signMessage"
+    subtitle="Sign message following the EIP191 standard"
+    link="/docs/nextjs-sdk/signMessage"
+  />
+
+  <TechnologyCard
+    icon={<IoLockClosedOutline size={"1.5rem"} />}
+    title="signTypedData"
+    subtitle="Sign typed data following the EIP712 standard"
+    link="/docs/nextjs-sdk/signTypedData"
   />
 </div>
 

--- a/content/docs/nextjs-sdk/v2migration.mdx
+++ b/content/docs/nextjs-sdk/v2migration.mdx
@@ -323,6 +323,15 @@ In V1, the AuthToken was a combination of the user login method and the client A
 | - | <ExternalLink href="/docs/nextjs-sdk/getNftCollections#get-nft-collections">`getNftCollections(oktoClient)`</ExternalLink> | - Retrieves NFT collection metadata |
 | [`orderHistory(query)`](https://docsv1.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docsv1.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docsv1.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | <ExternalLink href="/docs/nextjs-sdk/getOrdersHistory#get-orders-history">`getOrdersHistory(oktoClient, filters?)`</ExternalLink> | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
 
+### Message Signing
+
+The Message Signing methods enables the creation of signatures for messages or structured data. The signing process is initiated through the OktoClient instance.
+
+| V1 Function | V2 Function | Changes |
+|---------|-------------|---------------|
+| - | <ExternalLink href="/docs/nextjs-sdk/signMessage">`oktoClient.signMessage(message)`</ExternalLink> | - Signs message following the EIP191 standard |
+| - | <ExternalLink href="/docs/nextjs-sdk/signTypedData">`oktoClient.signTypedData(data)`</ExternalLink> | - Signs typed data following the EIP712 standard | 
+
 ### Intent Functions
 
 All intents are available in both abstracted and detailed flows. In the detailed flow, intents can be converted into a user operation (UserOp), signed, and executed on the Okto chain as separate calls. In the abstracted flow, these three steps are combined into a single call for a more seamless experience.

--- a/content/docs/okto-sdk/feature-support.mdx
+++ b/content/docs/okto-sdk/feature-support.mdx
@@ -147,8 +147,8 @@ The Okto SDK supports multiple blockchain ecosystems including EVM chains, Solan
       name: "Message Signing",
       description: "Sign arbitrary messages using the wallet's private key",
       support: {
-        SDKs: "🔜",
-        "Wagmi Adapter": "🔜",
+        SDKs: "✅",
+        "Wagmi Adapter": "✅",
         Chains: ["EVM"]
       }
     },

--- a/content/docs/openapi/getting-started.mdx
+++ b/content/docs/openapi/getting-started.mdx
@@ -77,6 +77,8 @@ JSON-RPC methods directly interact with the Okto Gateway and are primarily used 
 | <ExternalLink href="/docs/openapi/tokenTransfer">`POST https://sandbox-okto-gateway.oktostage.com/rpc`</ExternalLink> | `Content-Type: application/json` `Authorization: Bearer <OKTO_AUTH_TOKEN>` | Handles token transfers between addresses. |
 | <ExternalLink href="/docs/openapi/nftTransfer">`POST https://sandbox-okto-gateway.oktostage.com/rpc`</ExternalLink> | `Content-Type: application/json` `Authorization: Bearer <OKTO_AUTH_TOKEN>` | Handles NFT transfers between addresses. |
 | <ExternalLink href="/docs/openapi/evmRawTransaction">`POST https://sandbox-okto-gateway.oktostage.com/rpc`</ExternalLink> | `Content-Type: application/json` `Authorization: Bearer <OKTO_AUTH_TOKEN>` | Handles custom EVM transactions with specified parameters. |
+| <ExternalLink href="/docs/openapi/signMessage">`POST https://sandbox-okto-gateway.oktostage.com/rpc`</ExternalLink> | `Content-Type: application/json` `Authorization: Bearer <OKTO_AUTH_TOKEN>` |  Signs messages following the EIP191 standard. |
+| <ExternalLink href="/docs/openapi/signTypedData">`POST https://sandbox-okto-gateway.oktostage.com/rpc`</ExternalLink> | `Content-Type: application/json` `Authorization: Bearer <OKTO_AUTH_TOKEN>` | Signs typed data following the EIP712 standard. |
 
 ### REST APIs
 

--- a/content/docs/openapi/index.mdx
+++ b/content/docs/openapi/index.mdx
@@ -151,7 +151,7 @@ To start integrating with Okto APIs:
     className="h-25"
     icon={<IoConstructOutline size={"1.5rem"} />}
     title="Usage & Features"
-    subtitle="Explore intents, and explorer API"
+    subtitle="Explore intents, message signing and explorer API"
     link="/docs/openapi/intents"
   />
   <TechnologyCard

--- a/content/docs/react-native-sdk/index.mdx
+++ b/content/docs/react-native-sdk/index.mdx
@@ -683,6 +683,15 @@ For more examples and advanced usage, check out the [Template Repo](https://gith
 | `const orders = await getOrdersHistory(oktoClient);` | Get transaction order history | <ExternalLink href="/docs/react-native-sdk/getOrdersHistory">Method Overview</ExternalLink> |
 | `const collections = await getNftCollections(oktoClient);` | Get NFT collections | <ExternalLink href="/docs/react-native-sdk/getNFTCollection">Method Overview</ExternalLink> |
 
+### Message Signing
+
+Enables the creation of signatures for messages or object data. The signing process is initiated through the OktoClient instance.
+
+| Command | Description | Documentation |
+|---------|-------------|---------------|
+| `const signature = await oktoClient.signMessage(message);` | Signs messages following the EIP191 standard | <ExternalLink href="/docs/react-native-sdk/signMessage">Method Overview</ExternalLink> |
+| `const signature = await oktoClient.signTypedData(data);` | Signs typed data following the EIP712 standard | <ExternalLink href="/docs/react-native-sdk/signTypedData">Method Overview</ExternalLink> |
+
 ### User Operations (Intents)
 
 Intents are pre-built action templates within the Okto SDK that simplify common Web3 tasks. They provide one-liner functions for complex blockchain interactions.

--- a/content/docs/react-native-sdk/overview.mdx
+++ b/content/docs/react-native-sdk/overview.mdx
@@ -62,7 +62,7 @@ Kickstart your project by following our [Quickstart Guide](/docs/react-native-sd
     className="h-25"
     icon={<IoConstructOutline size={"1.5rem"} />}
     title="Usage & Features"
-    subtitle="Explore hooks, explorer functions, and intent operations"
+    subtitle="Explore hooks, explorer functions, message signing and intent operations"
     link="/docs/react-native-sdk/usage-overview"
   />
   <TechnologyCard

--- a/content/docs/react-native-sdk/usage-overview.mdx
+++ b/content/docs/react-native-sdk/usage-overview.mdx
@@ -14,7 +14,8 @@ import {
   IoServerOutline,
   IoAppsOutline,
   IoListOutline,
-  IoRocketOutline
+  IoRocketOutline,
+  IoLockClosedOutline
 } from "react-icons/io5";
 
 The Okto React Native SDK provides a comprehensive set of tools and hooks for integrating blockchain functionality into your React Native applications. This guide will help you understand the main components and features available in the SDK.
@@ -119,6 +120,24 @@ The Okto React Native SDK provides a comprehensive set of tools and hooks for in
     title="getTokens"
     subtitle="List available tokens and their details"
     link="/docs/react-native-sdk/getTokens"
+  />
+</div>
+
+## Message Signing
+
+<div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-6 lg:gap-8">
+  <TechnologyCard
+    icon={<IoLockClosedOutline size={"1.5rem"} />}
+    title="signMessage"
+    subtitle="Sign message following the EIP191 standard"
+    link="/docs/react-native-sdk/signMessage"
+  />
+
+  <TechnologyCard
+    icon={<IoLockClosedOutline size={"1.5rem"} />}
+    title="signTypedData"
+    subtitle="Sign typed data following the EIP712 standard"
+    link="/docs/react-native-sdk/signTypedData"
   />
 </div>
 

--- a/content/docs/react-native-sdk/v2migration.mdx
+++ b/content/docs/react-native-sdk/v2migration.mdx
@@ -282,6 +282,15 @@ In V1, the AuthToken was a combination of the user login method and the client A
 | - | <ExternalLink href="/docs/react-native-sdk/getNftCollections#get-nft-collections">`getNftCollections(oktoClient)`</ExternalLink> | - Retrieves NFT collection metadata |
 | [`orderHistory(query)`](https://docsv1.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docsv1.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docsv1.okto.tech/docs/react-native-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | <ExternalLink href="/docs/react-native-sdk/getOrderHistory#get-orders-history">`getOrdersHistory(oktoClient, filters?)`</ExternalLink> | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
 
+### Message Signing
+
+The Message Signing methods enables the creation of signatures for messages or structured data. The signing process is initiated through the OktoClient instance.
+
+| V1 Function | V2 Function | Changes |
+|---------|-------------|---------------|
+| - | <ExternalLink href="/docs/react-sdk/signMessage">`oktoClient.signMessage(message)`</ExternalLink> | - Signs message following the EIP191 standard |
+| - | <ExternalLink href="/docs/react-sdk/signTypedData">`oktoClient.signTypedData(data)`</ExternalLink> | - Signs typed data following the EIP712 standard | 
+
 ### Intent Functions
 
 All intents are available in both abstracted and detailed flows. In the detailed flow, intents can be converted into a user operation (UserOp), signed, and executed on the Okto chain as separate calls. In the abstracted flow, these three steps are combined into a single call for a more seamless experience.

--- a/content/docs/react-sdk/index.mdx
+++ b/content/docs/react-sdk/index.mdx
@@ -440,6 +440,15 @@ For more examples and advanced usage, check out the [Template Repo](https://gith
 | `const orders = await getOrdersHistory(oktoClient);` | Get transaction order history | <ExternalLink href="/docs/react-sdk/getOrdersHistory">Method Overview</ExternalLink> |
 | `const collections = await getNftCollections(oktoClient);` | Get NFT collections | <ExternalLink href="/docs/react-sdk/getNFTCollections">Method Overview</ExternalLink> |
 
+### Message Signing
+
+Enables the creation of signatures for messages or object data. The signing process is initiated through the OktoClient instance.
+
+| Command | Description | Documentation |
+|---------|-------------|---------------|
+| `const signature = await oktoClient.signMessage(message);` | Signs messages following the EIP191 standard | <ExternalLink href="/docs/react-sdk/signMessage">Method Overview</ExternalLink> |
+| `const signature = await oktoClient.signTypedData(data);` | Signs typed data following the EIP712 standard | <ExternalLink href="/docs/react-sdk/signTypedData">Method Overview</ExternalLink> |
+
 ### User Operations (Intents)
 
 Intents are pre-built action templates within the Okto SDK that simplify common Web3 tasks. They provide one-liner functions for complex blockchain interactions.

--- a/content/docs/react-sdk/overview.mdx
+++ b/content/docs/react-sdk/overview.mdx
@@ -68,7 +68,7 @@ Kickstart your project by following our [Quickstart Guide](/docs/react-sdk). Thi
     className="h-25"
     icon={<IoConstructOutline size={"1.5rem"} />}
     title="Usage & Features"
-    subtitle="Explore hooks, explorer functions, and intent operations"
+    subtitle="Explore hooks, explorer functions, message signing and intent operations"
     link="/docs/react-sdk/usage-overview"
   />
   <TechnologyCard

--- a/content/docs/react-sdk/usage-overview.mdx
+++ b/content/docs/react-sdk/usage-overview.mdx
@@ -14,7 +14,8 @@ import {
   IoServerOutline,
   IoAppsOutline,
   IoListOutline,
-  IoRocketOutline
+  IoRocketOutline,
+  IoLockClosedOutline
 } from "react-icons/io5";
 
 The Okto React SDK provides a comprehensive set of tools and hooks for integrating blockchain functionality into your React applications. This guide will help you understand the main components and features available in the SDK.
@@ -119,6 +120,24 @@ The Okto React SDK provides a comprehensive set of tools and hooks for integrati
     title="getTokens"
     subtitle="List available tokens and their details"
     link="/docs/react-sdk/getTokens"
+  />
+</div>
+
+## Message Signing
+
+<div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-6 lg:gap-8">
+  <TechnologyCard
+    icon={<IoLockClosedOutline size={"1.5rem"} />}
+    title="signMessage"
+    subtitle="Sign message following the EIP191 standard"
+    link="/docs/react-sdk/signMessage"
+  />
+
+  <TechnologyCard
+    icon={<IoLockClosedOutline size={"1.5rem"} />}
+    title="signTypedData"
+    subtitle="Sign typed data following the EIP712 standard"
+    link="/docs/react-sdk/signTypedData"
   />
 </div>
 

--- a/content/docs/react-sdk/v2migration.mdx
+++ b/content/docs/react-sdk/v2migration.mdx
@@ -286,6 +286,15 @@ In V1, the AuthToken was a combination of the user login method and the client A
 | - | <ExternalLink href="/docs/react-sdk/getNftCollections#get-nft-collections">`getNftCollections(oktoClient)`</ExternalLink> | - Retrieves NFT collection metadata |
 | [`orderHistory(query)`](https://docsv1.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-tokens#fetch-order-history) <br/> [`getNftOrderDetails(query)`](https://docsv1.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/transfer-nfts#get-nft-order-details) <br/> [`getRawTransactionStatus(query)`](https://docsv1.okto.tech/docs/react-sdk/okto-embedded-wallet/use-user-embedded-wallet/raw-transactions#get-raw-transactions) | <ExternalLink href="/docs/react-sdk/getOrdersHistory#get-orders-history">`getOrdersHistory(oktoClient, filters?)`</ExternalLink> | - All order history functions are now combined into one<br/>- Retrieves order history for token transfers, NFT transfers, and raw transactions using filter parameters |
 
+### Message Signing
+
+The Message Signing methods enables the creation of signatures for messages or structured data. The signing process is initiated through the OktoClient instance.
+
+| V1 Function | V2 Function | Changes |
+|---------|-------------|---------------|
+| - | <ExternalLink href="/docs/react-sdk/signMessage">`oktoClient.signMessage(message)`</ExternalLink> | - Signs message following the EIP191 standard |
+| - | <ExternalLink href="/docs/react-sdk/signTypedData">`oktoClient.signTypedData(data)`</ExternalLink> | - Signs typed data following the EIP712 standard | 
+
 ### Intent Functions
 
 All intents are available in both abstracted and detailed flows. In the detailed flow, intents can be converted into a user operation (UserOp), signed, and executed on the Okto chain as separate calls. In the abstracted flow, these three steps are combined into a single call for a more seamless experience.

--- a/content/docs/typescript-sdk/(Explorer)/getAccount.mdx
+++ b/content/docs/typescript-sdk/(Explorer)/getAccount.mdx
@@ -15,42 +15,11 @@ import '../../styles.css';
 
 Okto SDK provides the `getAccount()` method to retrieve details of wallets connected to the current user's Okto account. This includes both embedded wallets created via Okto and external wallets connected by the user (e.g., MetaMask, Phantom).
 
-<ChainSupportStatus 
-/>
-
-### Method Overview
-
-| Methods                                                                         | Description                          |                 
-|---------------------------------------------------------------------------------|--------------------------------------|
-| <sub><i>async</i></sub> [`getAccount`](#get-account) | Get the account of a user |
-
-<div className="method-box">
-
-## Get Account
-
-<sub><i>async</i></sub> `getAccount()` retrieves the list of all wallets associated with the currently authenticated user. 
-
-In Okto, an **account** represents the user's identity in the Okto ecosystem, encompassing both embedded wallets seamlessly created by Okto and external wallets users choose to connect.
-
-### Parameters
-
-| Parameter   | Type                        | Description                            | 
-|-------------|-----------------------------|----------------------------------------|
-| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |
-
-### Response
-
-<Callout title="Success Response">
-
-| Field Name | Type                  | Description                                   | 
-|------------|-----------------------|-----------------------------------------------|
-| `result`   | [`Promise<Wallet[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the list of wallets | 
-
-</Callout>
+<ChainSupportStatus />
 
 ### Example
 
-<Accordions>
+<Accordions defaultValue="Usage">
 <Accordion title="Usage">
 <Tabs items={['Typescript']}>
   <Tab value="Typescript">
@@ -81,6 +50,35 @@ In Okto, an **account** represents the user's identity in the Okto ecosystem, en
 </Accordion>
 </Accordions>
 
+### Method Overview
+
+| Methods                                                                         | Description                          |                 
+|---------------------------------------------------------------------------------|--------------------------------------|
+| <sub><i>async</i></sub> [`getAccount`](#get-account) | Get the account of a user |
+
+<div className="method-box">
+
+## Get Account
+
+<sub><i>async</i></sub> `getAccount()` retrieves the list of all wallets associated with the currently authenticated user. 
+
+In Okto, an **account** represents the user's identity in the Okto ecosystem, encompassing both embedded wallets seamlessly created by Okto and external wallets users choose to connect.
+
+### Parameters
+
+| Parameter   | Type                        | Description                            | 
+|-------------|-----------------------------|----------------------------------------|
+| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |
+
+### Response
+
+<Callout title="Success Response">
+
+| Field Name | Type                  | Description                                   | 
+|------------|-----------------------|-----------------------------------------------|
+| `result`   | [`Promise<Wallet[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the list of wallets | 
+
+</Callout>
 </div>
 
 <Callout title="Note">

--- a/content/docs/typescript-sdk/(Explorer)/getChains.mdx
+++ b/content/docs/typescript-sdk/(Explorer)/getChains.mdx
@@ -15,40 +15,11 @@ import '../../styles.css';
 
 The `getChains` function retrieves a list of all blockchain networks supported by Okto.
 
-<ChainSupportStatus 
-/>
-
-### Method Overview
-
-| Methods                                                                         | Description                          |                 
-|---------------------------------------------------------------------------------|--------------------------------------|
-| <sub><i>async</i></sub> [`getChains`](#get-chains) | Get all the supported chains |
-
-<div className="method-box">
-
-## Get Chains
-
-<sub><i>async</i></sub> `getChains(OktoClient)` returns the list of supported chains.
-
-### Parameters
-
-| Parameter   | Type                        | Description                            | 
-|-------------|-----------------------------|----------------------------------------|
-| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |
-
-### Response
-
-<Callout title="Success Response">
-
-| Field Name | Type                  | Description                                   | 
-|------------|-----------------------|-----------------------------------------------|
-| `result`   | [`Promise<GetSupportedNetworksResponseData[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the list of supported chains | 
-
-</Callout>
+<ChainSupportStatus />
 
 ### Example
 
-<Accordions>
+<Accordions defaultValue="Usage">
 <Accordion title="Usage">
 <Tabs items={['Typescript']}>
   <Tab value="Typescript">
@@ -122,6 +93,33 @@ The `getChains` function retrieves a list of all blockchain networks supported b
 </Accordion>
 </Accordions>
 
+### Method Overview
+
+| Methods                                                                         | Description                          |                 
+|---------------------------------------------------------------------------------|--------------------------------------|
+| <sub><i>async</i></sub> [`getChains`](#get-chains) | Get all the supported chains |
+
+<div className="method-box">
+
+## Get Chains
+
+<sub><i>async</i></sub> `getChains(OktoClient)` returns the list of supported chains.
+
+### Parameters
+
+| Parameter   | Type                        | Description                            | 
+|-------------|-----------------------------|----------------------------------------|
+| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |
+
+### Response
+
+<Callout title="Success Response">
+
+| Field Name | Type                  | Description                                   | 
+|------------|-----------------------|-----------------------------------------------|
+| `result`   | [`Promise<GetSupportedNetworksResponseData[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the list of supported chains | 
+
+</Callout>
 </div>
 
 <Callout title="Note">

--- a/content/docs/typescript-sdk/(Explorer)/getNftCollections.mdx
+++ b/content/docs/typescript-sdk/(Explorer)/getNftCollections.mdx
@@ -20,6 +20,43 @@ import '../../styles.css';
   ]}
 />
 
+### Example
+
+<Accordions defaultValue="Usage">
+<Accordion title="Usage">
+<Tabs items={['Typescript']}>
+  <Tab value="Typescript">
+    ```typescript
+    import { getNftCollections } from "@okto_web3/core-js-sdk/explorer"; // [!code highlight]
+    
+    const nftCollections = await getNftCollections(); // [!code highlight]
+    ```
+  </Tab>
+</Tabs>
+</Accordion>
+<Accordion title="Success Response">
+```json
+{
+    "status": "success",
+    "data": {
+        "collections": [
+            {
+                "caip_id": "eip155:8453",
+                "network_name": "BASE",
+                "entity_type": "ERC721",
+                "collection_address": "0x19fc518b9eed93f70aa4b49133d303101699467a",
+                "collection_name": "EXAMPLE_COLLECTION",
+                "description": "Collection description",
+                "collection_image": "https://example.com/image.png",
+                "whitelisted": true
+            }
+        ]
+    }
+}
+```
+</Accordion>
+</Accordions>
+
 ### Method Overview
 
 | Methods                                                                         | Description                          |                 
@@ -47,22 +84,6 @@ import '../../styles.css';
 | `result`   | [`Promise<NFTOrderDetails[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the list of NFT collections | 
 
 </Callout>
-
-
-<Accordions>
-<Accordion title="Example">
-<Tabs items={['Typescript']}>
-  <Tab value="Typescript">
-    ```typescript
-    import { getNftCollections } from "@okto_web3/core-js-sdk/explorer"; // [!code highlight]
-    
-    const nftCollections = await getNftCollections(); // [!code highlight]
-    ```
-  </Tab>
-</Tabs>
-</Accordion>
-</Accordions>
-
 </div>
 
 <Callout title="Note">

--- a/content/docs/typescript-sdk/(Explorer)/getOrdersHistory.mdx
+++ b/content/docs/typescript-sdk/(Explorer)/getOrdersHistory.mdx
@@ -15,40 +15,11 @@ import '../../styles.css';
 
 The `getOrdersHistory` function retrieves the list of orders for the authenticated user.
 
-<ChainSupportStatus 
-/>
-
-### Method Overview
-
-| Methods                                                                         | Description                          |                 
-|---------------------------------------------------------------------------------|--------------------------------------|
-| <sub><i>async</i></sub> [`getOrdersHistory`](#get-orders-history) | Get the orders history of a user |
-
-<div className="method-box">
-
-## Get Orders History
-
-<sub><i>async</i></sub> `getOrdersHistory(OktoClient)` retrieves the user's order history.
-
-### Parameters
-
-| Parameter   | Type                        | Description                            | 
-|-------------|-----------------------------|----------------------------------------|
-| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |
-
-### Response
-
-<Callout title="Success Response">
-
-| Field Name | Type                  | Description                                   | 
-|------------|-----------------------|-----------------------------------------------|
-| `result`   | [`Promise<Order[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the list of orders for a user | 
-
-</Callout>
+<ChainSupportStatus />
 
 ### Example
 
-<Accordions>
+<Accordions defaultValue="Usage">
 <Accordion title="Usage">
 <Tabs items={['Typescript']}>
   <Tab value="Typescript">
@@ -97,6 +68,33 @@ The `getOrdersHistory` function retrieves the list of orders for the authenticat
 </Accordion>
 </Accordions>
 
+### Method Overview
+
+| Methods                                                                         | Description                          |                 
+|---------------------------------------------------------------------------------|--------------------------------------|
+| <sub><i>async</i></sub> [`getOrdersHistory`](#get-orders-history) | Get the orders history of a user |
+
+<div className="method-box">
+
+## Get Orders History
+
+<sub><i>async</i></sub> `getOrdersHistory(OktoClient)` retrieves the user's order history.
+
+### Parameters
+
+| Parameter   | Type                        | Description                            | 
+|-------------|-----------------------------|----------------------------------------|
+| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |
+
+### Response
+
+<Callout title="Success Response">
+
+| Field Name | Type                  | Description                                   | 
+|------------|-----------------------|-----------------------------------------------|
+| `result`   | [`Promise<Order[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the list of orders for a user | 
+
+</Callout>
 </div>
 
 <Callout title="Important: Transaction Lifecycle">

--- a/content/docs/typescript-sdk/(Explorer)/getPortfolio.mdx
+++ b/content/docs/typescript-sdk/(Explorer)/getPortfolio.mdx
@@ -15,40 +15,11 @@ import '../../styles.css';
 
 The `getPortfolio` function retrieves the aggregated portfolio for the authenticated user.
 
-<ChainSupportStatus 
-/>
-
-### Method Overview
-
-| Methods                                                                         | Description                          |                 
-|---------------------------------------------------------------------------------|--------------------------------------|
-| <sub><i>async</i></sub> [`getPortfolio`](#get-portfolio) | Get the portfolio of a user |
-
-<div className="method-box">
-
-## Get Portfolio
-
-<sub><i>async</i></sub> `getPortfolio(OktoClient)` retrieves the user's aggregated portfolio data.
-
-### Parameters
-
-| Parameter   | Type                        | Description                            | 
-|-------------|-----------------------------|----------------------------------------|
-| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |                                        |
-
-### Response
-
-<Callout title="Success Response">
-
-| Field Name | Type                  | Description                                   | 
-|------------|-----------------------|-----------------------------------------------|
-| `result`   | [`Promise<UserPortfolioData>`](/docs/typescript-sdk/technical-reference#models) | Returns the portfolio of the user | 
-
-</Callout>
+<ChainSupportStatus />
 
 ### Example
 
-<Accordions>
+<Accordions defaultValue="Usage">
 <Accordion title="Usage">
 <Tabs items={['Typescript']}>
   <Tab value="Typescript">
@@ -115,6 +86,33 @@ The `getPortfolio` function retrieves the aggregated portfolio for the authentic
 </Accordion>
 </Accordions>
 
+### Method Overview
+
+| Methods                                                                         | Description                          |                 
+|---------------------------------------------------------------------------------|--------------------------------------|
+| <sub><i>async</i></sub> [`getPortfolio`](#get-portfolio) | Get the portfolio of a user |
+
+<div className="method-box">
+
+## Get Portfolio
+
+<sub><i>async</i></sub> `getPortfolio(OktoClient)` retrieves the user's aggregated portfolio data.
+
+### Parameters
+
+| Parameter   | Type                        | Description                            | 
+|-------------|-----------------------------|----------------------------------------|
+| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |                                        |
+
+### Response
+
+<Callout title="Success Response">
+
+| Field Name | Type                  | Description                                   | 
+|------------|-----------------------|-----------------------------------------------|
+| `result`   | [`Promise<UserPortfolioData>`](/docs/typescript-sdk/technical-reference#models) | Returns the portfolio of the user | 
+
+</Callout>
 </div>
 
 <Callout title="Note">

--- a/content/docs/typescript-sdk/(Explorer)/getPortfolioActivity.mdx
+++ b/content/docs/typescript-sdk/(Explorer)/getPortfolioActivity.mdx
@@ -15,40 +15,11 @@ import '../../styles.css';
 
 The `getPortfolioActivity` function retrieves the portfolio activity for the authenticated user.
 
-<ChainSupportStatus 
-/>
-
-### Method Overview
-
-| Methods                                                                         | Description                          |                 
-|---------------------------------------------------------------------------------|--------------------------------------|
-| <sub><i>async</i></sub> [`getPortfolioActivity`](#get-portfolio-activity) | Get the portfolio activity of a user |
-
-<div className="method-box">
-
-## Get Portfolio Activity
-
-<sub><i>async</i></sub> `getPortfolioActivity(OktoClient)` retrieves the user's portfolio activity history.
-
-### Parameters
-
-| Parameter   | Type                        | Description                            | 
-|-------------|-----------------------------|----------------------------------------|
-| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |                                        |
-
-### Response
-
-<Callout title="Success Response">
-
-| Field Name | Type                  | Description                                   | 
-|------------|-----------------------|-----------------------------------------------|
-| `result`   | [`Promise<UserPortfolioActivity[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the portfolio activity of the user | 
-
-</Callout>
+<ChainSupportStatus />
 
 ### Example
 
-<Accordions>
+<Accordions defaultValue="Usage">
 <Accordion title="Usage">
 <Tabs items={['Typescript']}>
   <Tab value="Typescript">
@@ -121,6 +92,33 @@ The `getPortfolioActivity` function retrieves the portfolio activity for the aut
 </Accordion>
 </Accordions>
 
+### Method Overview
+
+| Methods                                                                         | Description                          |                 
+|---------------------------------------------------------------------------------|--------------------------------------|
+| <sub><i>async</i></sub> [`getPortfolioActivity`](#get-portfolio-activity) | Get the portfolio activity of a user |
+
+<div className="method-box">
+
+## Get Portfolio Activity
+
+<sub><i>async</i></sub> `getPortfolioActivity(OktoClient)` retrieves the user's portfolio activity history.
+
+### Parameters
+
+| Parameter   | Type                        | Description                            | 
+|-------------|-----------------------------|----------------------------------------|
+| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |                                        |
+
+### Response
+
+<Callout title="Success Response">
+
+| Field Name | Type                  | Description                                   | 
+|------------|-----------------------|-----------------------------------------------|
+| `result`   | [`Promise<UserPortfolioActivity[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the portfolio activity of the user | 
+
+</Callout>
 </div>
 
 <Callout title="Note">

--- a/content/docs/typescript-sdk/(Explorer)/getPortfolioNFT.mdx
+++ b/content/docs/typescript-sdk/(Explorer)/getPortfolioNFT.mdx
@@ -22,37 +22,9 @@ The `getPortfolioNFT` function retrieves the list of NFTs in the authenticated u
   ]}
 />
 
-### Method Overview
-
-| Methods                                                                         | Description                          |                 
-|---------------------------------------------------------------------------------|--------------------------------------|
-| <sub><i>async</i></sub> [`getPortfolioNFT`](#get-portfolio-nft) | Get the NFT portfolio of a user |
-
-<div className="method-box">
-
-## Get Portfolio NFT
-
-<sub><i>async</i></sub> `getPortfolioNFT(OktoClient)` returns the NFT portfolio of the user.
-
-### Parameters
-
-| Parameter   | Type                        | Description                            | 
-|-------------|-----------------------------|----------------------------------------|
-| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |                                        |
-
-### Response
-
-<Callout title="Success Response">
-
-| Field Name | Type                  | Description                                   | 
-|------------|-----------------------|-----------------------------------------------|
-| `result`   | [`Promise<UserNFTBalance[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the NFT portfolio of the user | 
-
-</Callout>
-
 ### Example
 
-<Accordions>
+<Accordions defaultValue="Usage">
 <Accordion title="Usage">
 <Tabs items={['Typescript']}>
   <Tab value="Typescript">
@@ -94,6 +66,33 @@ The `getPortfolioNFT` function retrieves the list of NFTs in the authenticated u
 </Accordion>
 </Accordions>
 
+### Method Overview
+
+| Methods                                                                         | Description                          |                 
+|---------------------------------------------------------------------------------|--------------------------------------|
+| <sub><i>async</i></sub> [`getPortfolioNFT`](#get-portfolio-nft) | Get the NFT portfolio of a user |
+
+<div className="method-box">
+
+## Get Portfolio NFT
+
+<sub><i>async</i></sub> `getPortfolioNFT(OktoClient)` returns the NFT portfolio of the user.
+
+### Parameters
+
+| Parameter   | Type                        | Description                            | 
+|-------------|-----------------------------|----------------------------------------|
+| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |                                        |
+
+### Response
+
+<Callout title="Success Response">
+
+| Field Name | Type                  | Description                                   | 
+|------------|-----------------------|-----------------------------------------------|
+| `result`   | [`Promise<UserNFTBalance[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the NFT portfolio of the user | 
+
+</Callout>
 </div>
 
 <Callout title="Note">

--- a/content/docs/typescript-sdk/(Explorer)/getTokens.mdx
+++ b/content/docs/typescript-sdk/(Explorer)/getTokens.mdx
@@ -15,40 +15,11 @@ import '../../styles.css';
 
 The `getTokens` function fetches the list of supported tokens from the backend.
 
-<ChainSupportStatus 
-/>
-
-### Method Overview
-
-| Methods                                                                         | Description                          |                 
-|---------------------------------------------------------------------------------|--------------------------------------|
-| <sub><i>async</i></sub> [`getTokens`](#get-tokens) | Get all the supported tokens |
-
-<div className="method-box">
-
-## Get Tokens
-
-<sub><i>async</i></sub> `getTokens(OktoClient)` returns the list of supported tokens.
-
-### Parameters
-
-| Parameter   | Type                        | Description                            | 
-|-------------|-----------------------------|----------------------------------------|
-| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |
-
-### Response
-
-<Callout title="Success Response">
-
-| Field Name | Type                  | Description                                   | 
-|------------|-----------------------|-----------------------------------------------|
-| `result`   | [`Promise<GetSupportedNetworksResponseData[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the list of supported tokens | 
-
-</Callout>
+<ChainSupportStatus />
 
 ### Example
 
-<Accordions>
+<Accordions defaultValue="Usage">
 <Accordion title="Usage">
 <Tabs items={['Typescript']}>
   <Tab value="Typescript">
@@ -105,6 +76,33 @@ The `getTokens` function fetches the list of supported tokens from the backend.
 </Accordion>
 </Accordions>
 
+### Method Overview
+
+| Methods                                                                         | Description                          |                 
+|---------------------------------------------------------------------------------|--------------------------------------|
+| <sub><i>async</i></sub> [`getTokens`](#get-tokens) | Get all the supported tokens |
+
+<div className="method-box">
+
+## Get Tokens
+
+<sub><i>async</i></sub> `getTokens(OktoClient)` returns the list of supported tokens.
+
+### Parameters
+
+| Parameter   | Type                        | Description                            | 
+|-------------|-----------------------------|----------------------------------------|
+| `oktoClient` | [`OktoClient`](/docs/typescript-sdk/technical-reference#models) | Okto client |
+
+### Response
+
+<Callout title="Success Response">
+
+| Field Name | Type                  | Description                                   | 
+|------------|-----------------------|-----------------------------------------------|
+| `result`   | [`Promise<GetSupportedNetworksResponseData[]>`](/docs/typescript-sdk/technical-reference#models) | Returns the list of supported tokens | 
+
+</Callout>
 </div>
 
 <Callout title="Note">

--- a/content/docs/typescript-sdk/index.mdx
+++ b/content/docs/typescript-sdk/index.mdx
@@ -281,6 +281,15 @@ Now that you've completed your first user operation, you're ready to explore mor
 | `const orders = await getOrdersHistory(oktoClient);` | Get transaction order history | <ExternalLink href="/docs/typescript-sdk/(Explorer)/getOrdersHistory">Method Overview</ExternalLink> |
 | `const collections = await getNftCollections(oktoClient);` | Get NFT collections | <ExternalLink href="/docs/typescript-sdk/(Explorer)/getNftCollections">Method Overview</ExternalLink> |
 
+### Message Signing
+
+Enables the creation of signatures for messages or object data. The signing process is initiated through the OktoClient instance.
+
+| Command | Description | Documentation |
+|---------|-------------|---------------|
+| `const signature = await oktoClient.signMessage(message);` | Signs messages following the EIP191 standard | <ExternalLink href="/docs/typescript-sdk/signMessage">Method Overview</ExternalLink> |
+| `const signature = await oktoClient.signTypedData(data);` | Signs typed data following the EIP712 standard | <ExternalLink href="/docs/typescript-sdk/signTypedData">Method Overview</ExternalLink> |
+
 ### User Operations (Intents)
 
 Intents are pre-built action templates within the Okto SDK that simplify common Web3 tasks. They provide one-liner functions for complex blockchain interactions.

--- a/content/docs/typescript-sdk/overview.mdx
+++ b/content/docs/typescript-sdk/overview.mdx
@@ -66,7 +66,7 @@ Kickstart your project by following our [Quickstart Guide](/docs/typescript-sdk)
     className="h-25"
     icon={<IoConstructOutline size={"1.5rem"} />}
     title="Usage & Features"
-    subtitle="Explore hooks, explorer functions, and intent operations"
+    subtitle="Explore hooks, explorer functions, message signing and intent operations"
     link="/docs/typescript-sdk/usage-overview"
   />
   <TechnologyCard

--- a/content/docs/typescript-sdk/usage-overview.mdx
+++ b/content/docs/typescript-sdk/usage-overview.mdx
@@ -12,7 +12,8 @@ import {
   IoCodeSlashOutline,
   IoServerOutline,
   IoAppsOutline,
-  IoListOutline
+  IoListOutline,
+  IoLockClosedOutline
 } from "react-icons/io5";
 
 This section provides a comprehensive overview of the functions available in the Typescript SDK. These functions empower you to interact seamlessly with the Okto platform—from initiating transaction operations to retrieving data related to accounts, portfolios, and more.
@@ -117,6 +118,24 @@ This section provides a comprehensive overview of the functions available in the
     title="getTokens"
     subtitle="List available tokens and their details"
     link="/docs/typescript-sdk/getTokens"
+  />
+</div>
+
+## Message Signing
+
+<div className="grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-6 lg:gap-8">
+  <TechnologyCard
+    icon={<IoLockClosedOutline size={"1.5rem"} />}
+    title="signMessage"
+    subtitle="Sign message following the EIP191 standard"
+    link="/docs/typescript-sdk/signMessage"
+  />
+
+  <TechnologyCard
+    icon={<IoLockClosedOutline size={"1.5rem"} />}
+    title="signTypedData"
+    subtitle="Sign typed data following the EIP712 standard"
+    link="/docs/typescript-sdk/signTypedData"
   />
 </div>
 


### PR DESCRIPTION
Changes address in the PR:
- Add: Message Signing references throughout the docs wherever needed, including `overview-page`, `setup page`, `usage-overview` and `migration docs` (for all SDKs)
- Improve: the structure of the explorer function pages in **Typescript sdk**
- Update: the feature support section