### PR TITLE
Fix: the api migration docs and remove the testnet fund form

### DIFF
--- a/content/docs/developer-admin-dashboard/okto-faucet.mdx
+++ b/content/docs/developer-admin-dashboard/okto-faucet.mdx
@@ -43,6 +43,7 @@ You can request Okto Credits multiple times during development. If you run out, 
 
 Your current Okto Credit balance is always visible in the Okto Credits section of your dashboard. Monitor this balance regularly to ensure you have sufficient credits for your development activities.
 
+{/*
 ### **Need Testnet/Mainnet Funds? Fill out the form below:**
 
 <div style={{ width: '100%', maxWidth: '100%', margin: '0 auto' }}>
@@ -61,6 +62,7 @@ Your current Okto Credit balance is always visible in the Okto Credits section o
     }}
   ></iframe>
 </div>
+*/}
 
 ## Next Steps
 

--- a/content/docs/developer-admin-dashboard/sponsorship.mdx
+++ b/content/docs/developer-admin-dashboard/sponsorship.mdx
@@ -38,25 +38,28 @@ Sponsorship integrates with Okto's wallet infrastructure to automatically cover 
 1. Enable desired chains in your Okto dashboard
 2. Activate sponsorship for each chain
 3. Add native funds via airdrop or transfer to the sponsorship address.
-<CollapsibleCallout type="note" title="In case you're unable to obtain testnet tokens, you can request them by filling out the form below.">
 
-<div style={{ width: '100%', maxWidth: '100%', margin: '0 auto' }}>
-  <iframe
-    id="typeform-widget"
-    title="Troubleshooting Form"
-    src="https://form.typeform.com/to/oXtDR5xw"
-    width="100%"
-    height="470px"
-    frameBorder="0"
-    allowFullScreen
-    style={{ 
-      border: 'none', 
-      borderRadius: '5px',
-      boxShadow: '0 2px 8px rgba(0,0,0,0.05)'
-    }}
-  ></iframe>
-</div>
-</CollapsibleCallout>
+{/* 
+  <CollapsibleCallout type="note" title="In case you're unable to obtain testnet tokens, you can request them by filling out the form below.">
+    <div style={{ width: '100%', maxWidth: '100%', margin: '0 auto' }}>
+      <iframe
+        id="typeform-widget"
+        title="Troubleshooting Form"
+        src="https://form.typeform.com/to/oXtDR5xw"
+        width="100%"
+        height="470px"
+        frameBorder="0"
+        allowFullScreen
+        style={{ 
+          border: 'none', 
+          borderRadius: '5px',
+          boxShadow: '0 2px 8px rgba(0,0,0,0.05)'
+        }}
+      ></iframe>
+    </div>
+  </CollapsibleCallout> 
+*/}
+
 4. Enable/disable sponsorship as needed
 
 <CollapsibleCallout type="tip" title="Sponsorship Necessity">

--- a/content/docs/okto-layer/okto-token.mdx
+++ b/content/docs/okto-layer/okto-token.mdx
@@ -18,6 +18,7 @@ For development and testing purposes, you can use Okto Credits (testnet $OKTO). 
 
 To obtain testnet $OKTO for development purposes, please refer to the [Okto Faucet Guide](/docs/developer-admin-dashboard/okto-faucet).
 
+{/*
 ### **Need Testnet/Mainnet Funds?**
 To request funds, please complete the form below:
 
@@ -37,6 +38,7 @@ To request funds, please complete the form below:
     }}
   ></iframe>
 </div>
+*/}
 
 ## Additional Resources
 

--- a/content/docs/openapi/api-migration.mdx
+++ b/content/docs/openapi/api-migration.mdx
@@ -28,7 +28,7 @@ This guide provides a detailed walkthrough for migrating your application from [
 
 | V1 API Requests | V2 API Requests | Changes |
 |-----------------|-----------------|---------|
-| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v2/authenticate">POST `/api/v2/authenticate`</ExternalLink> | <ExternalLink href="/docs/openapi/authenticate/login-logout/loginUsingOktoAuth">POST `/api/v2/authenticate`</ExternalLink> | Returns session key on successful authentication |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v2/authenticate">POST `/api/v2/authenticate`</ExternalLink> | <ExternalLink href="/docs/openapi/authenticate/login-logout/loginUsingOktoAuth">POST `https://sandbox-okto-gateway.oktostage.com/rpc`</ExternalLink> | Unified RPC endpoint with `method="authenticate"` for login |
 | <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/authenticate/email">POST `/api/v1/authenticate/email`</ExternalLink> | Coming Soon | - |
 | <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/authenticate/email/verify">POST `/api/v1/authenticate/email/verify`</ExternalLink> | Coming Soon | - |
 | <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/authenticate/phone">POST `/api/v1/authenticate/phone`</ExternalLink> | Coming Soon | - |
@@ -37,38 +37,41 @@ This guide provides a detailed walkthrough for migrating your application from [
 | <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/authenticate/whatsapp/verify">POST `/api/v1/authenticate/whatsapp/verify`</ExternalLink> | Coming Soon | - |
 | <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/authenticate/jwt">POST `/api/v1/authenticate/jwt`</ExternalLink> | Coming Soon | - |
 | <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/wallet">GET `/api/v1/wallet`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-wallets">GET `/api/oc/v1/wallets`</ExternalLink> | Fetches all user wallets |
-| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/wallet">POST `/api/v1/wallet`</ExternalLink> | Deprecated | Wallets are auto-created. |
-| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/refresh_token">POST `/api/v1/refresh_token`</ExternalLink> | Coming Soon | - |
-| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/logout">POST `/api/v1/logout`</ExternalLink> | Deprecated | The session key expires after 7 days. |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/wallet">POST `/api/v1/wallet`</ExternalLink> | Deprecated | Wallets are auto-created|
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/refresh_token">POST `/api/v1/refresh_token`</ExternalLink> | Deprecated | - |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/logout">POST `/api/v1/logout`</ExternalLink> | Deprecated | Now managed through customizable sessions|
 | <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/user_from_token">GET `/api/v1/user_from_token`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/user-session-verify">GET `/api/oc/v1/verify-session`</ExternalLink> | Now returns detailed user information |
 | <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/supported/networks">GET `/api/v1/supported/networks`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-supported-networks">GET `/api/oc/v1/supported/networks`</ExternalLink> | Fetches details of all the enabled networks |
 | <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/supported/tokens">GET `/api/v1/supported/tokens`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-supported-tokens">GET `/api/oc/v1/supported/tokens`</ExternalLink> | Fetches details of all available tokens |
-| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/portfolio">GET `/api/v1/portfolio`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-portfolio">GET `/api/oc/v1/aggregated-portfolio`</ExternalLink> | - |
-| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/portfolio/activity">GET `/api/v1/portfolio/activity`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-portfolio-activity">GET `/api/oc/v1/portfolio/activity`</ExternalLink> | - |
-| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/transfer/tokens/execute">POST `/api/v1/transfer/tokens/execute`</ExternalLink> | Coming Soon | - |
-| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/orders">GET `/api/v1/orders`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-order-history">GET `/api/oc/v1/orders`</ExternalLink> | Fetch all the orders for all transactions |
-| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/portfolio/nft">GET `/api/v1/portfolio/nft`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-nft-portfolio">GET `/api/oc/v1/portfolio/nft`</ExternalLink> | - |
-| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/nft/transfer">POST `/api/v1/nft/transfer`</ExternalLink> | Coming Soon | - |
-| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/nft/order_details">GET `/api/v1/nft/order_details`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-order-history">GET `/api/oc/v1/orders`</ExternalLink> | Fetch all the orders for all transactions |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/portfolio">GET `/api/v1/portfolio`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-portfolio">GET `/api/oc/v1/aggregated-portfolio`</ExternalLink> | Retrieves the user's aggregated portfolio data |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/portfolio/activity">GET `/api/v1/portfolio/activity`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-portfolio-activity">GET `/api/oc/v1/portfolio/activity`</ExternalLink> | Retrieves user's portfolio activity |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/transfer/tokens/execute">POST `/api/v1/transfer/tokens/execute`</ExternalLink> | <ExternalLink href="/docs/openapi/tokenTransfer">POST `https://sandbox-okto-gateway.oktostage.com/rpc`</ExternalLink> | Unified RPC endpoint with `method="execute"` for Token Transfer |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/orders">GET `/api/v1/orders`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-order-history">GET `/api/oc/v1/orders`</ExternalLink> | Replaced by Get Order History |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/portfolio/nft">GET `/api/v1/portfolio/nft`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-nft-portfolio">GET `/api/oc/v1/portfolio/nft`</ExternalLink> | Retrieves user's NFT portfolio |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/nft/transfer">POST `/api/v1/nft/transfer`</ExternalLink> | <ExternalLink href="/docs/openapi/nftTransfer">POST `https://sandbox-okto-gateway.oktostage.com/rpc`</ExternalLink> | Unified RPC endpoint with `method="execute"` for NFT Transfer |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/nft/order_details">GET `/api/v1/nft/order_details`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-order-history">GET `/api/oc/v1/orders`</ExternalLink> | Replaced by Get Order History |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/readContractData">POST `/api/v1/readContractData` </ExternalLink> | - | - |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/POST/api/v1/rawtransaction/execute">POST `/api/v1/rawtransaction/execute`</ExternalLink> | <ExternalLink href="/docs/openapi/evmRawTransaction">POST `https://sandbox-okto-gateway.oktostage.com/rpc`</ExternalLink> | Unified RPC endpoint with `method="execute"` for EVM Raw Transaction |
+| <ExternalLink href="https://docsv1.okto.tech/api-docs#tag/client/GET/api/v1/rawtransaction/status">GET `/api/v1/rawtransaction/status`</ExternalLink> | <ExternalLink href="/docs/openapi/explorer/get-order-history">GET `/api/oc/v1/orders`</ExternalLink> | Replaced by Get Order History |
 
 ## Server API Reference
 
 | V1 API Requests | V2 API Requests | Changes |
 |-----------------|-----------------|---------|
-| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/wallet">GET /s2s/api/v1/wallet`</ExternalLink> | Coming Soon  | - |
-| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/POST/s2s/api/v1/wallet">POST /s2s/api/v1/wallet`</ExternalLink> | Coming Soon  | - |
-| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/portfolio">GET /s2s/api/v1/portfolio`</ExternalLink> | Coming Soon  | - |
-| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/portfolio/nft">GET /s2s/api/v1/portfolio/nft`</ExternalLink> | Coming Soon  | - |
-| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/portfolio/activity">GET /s2s/api/v1/portfolio/activity`</ExternalLink> | Coming Soon  | - |
-| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/supported/tokens">GET /s2s/api/v1/supported/tokens`</ExternalLink> | Coming Soon  | - |
-| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/POST/s2s/api/v1/bulk-wallets">POST /s2s/api/v1/bulk-wallets`</ExternalLink> | Coming Soon  | - |
+| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/wallet">GET `/s2s/api/v1/wallet`</ExternalLink> | Coming Soon  | - |
+| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/POST/s2s/api/v1/wallet">POST `/s2s/api/v1/wallet`</ExternalLink> | Coming Soon  | - |
+| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/portfolio">GET `/s2s/api/v1/portfolio`</ExternalLink> | Coming Soon  | - |
+| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/portfolio/nft">GET `/s2s/api/v1/portfolio/nft`</ExternalLink> | Coming Soon  | - |
+| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/portfolio/activity">GET `/s2s/api/v1/portfolio/activity`</ExternalLink> | Coming Soon  | - |
+| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/supported/tokens">GET `/s2s/api/v1/supported/tokens`</ExternalLink> | Coming Soon  | - |
+| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/POST/s2s/api/v1/bulk-wallets">POST `/s2s/api/v1/bulk-wallets`</ExternalLink> | Coming Soon  | - |
 | <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/POSTs2s/api/v2/nft/mint">POST `/s2s/api/v2/nft/mint`</ExternalLink> | Coming Soon | - |
 | <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/POSTs2s/api/v2/nft/transfer">POST `/s2s/api/v2/nft/transfer`</ExternalLink> | Coming Soon  | - |
 | <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/POSTs2s/api/v2/transfer/tokens/execute/">POST `/s2s/api/v2/transfer/tokens/execute/`</ExternalLink> | Coming Soon | - |
 | <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v2/bulk_order_details/">GET `/s2s/api/v2/bulk_order_details/`</ExternalLink> | Coming Soon | - |
-| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/POST/s2s/api/v1/readContractData">POST /s2s/api/v1/readContractData`</ExternalLink> | Coming Soon  | - |
-| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/POST/s2s/api/v1/rawtransaction/execute/">POST /s2s/api/v1/rawtransaction/execute/`</ExternalLink> | Coming Soon  | - |
-| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/rawtransaction/status/">GET /s2s/api/v1/rawtransaction/status/`</ExternalLink> | Coming Soon | - |
+| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/POST/s2s/api/v1/readContractData">POST `/s2s/api/v1/readContractData`</ExternalLink> | Coming Soon  | - |
+| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/POST/s2s/api/v1/rawtransaction/execute/">POST `/s2s/api/v1/rawtransaction/execute/`</ExternalLink> | Coming Soon  | - |
+| <ExternalLink href="https://docsv1.okto.tech/server-api-docs#tag/server/GET/s2s/api/v1/rawtransaction/status/">GET `/s2s/api/v1/rawtransaction/status/`</ExternalLink> | Coming Soon | - |
 
 <Callout title="Migration Support">
 For additional help:

--- a/content/docs/supported-chains.mdx
+++ b/content/docs/supported-chains.mdx
@@ -19,7 +19,7 @@ Overview of supported chains, wallet structure, testnet availability, and token 
 <Callout title="What is Type*?">
 **Type** refers to the family of chains or ecosystems a blockchain belongs to. For example, the EVM ecosystem includes all chains that run EVM-compatible nodes, sharing similar consensus mechanisms and transaction processing methods. Other ecosystems include Solana, Aptos, Bitcoin, and Cosmos, each with distinct approaches to transaction payload creation and processing. Understanding a chain’s type is essential for constructing the appropriate payloads when interacting with that blockchain.
 </Callout>
-
+{/*
 ### **Need Testnet/Mainnet Funds?**
 To request funds, please complete the form below:
 
@@ -39,6 +39,7 @@ To request funds, please complete the form below:
     }}
   ></iframe>
 </div>
+*/}
 
 ## Supported Chains
 


### PR DESCRIPTION
Changes address in this PR:
- Remove: the testnet/Mainnet fund form from all the pages
- Fix: the API migration docs endpoints and description