### PR TITLE
Sponsorship Updates across the SDKs

### DIFF
--- a/content/docs/nextjs-sdk/(Intents)/evmRawTransaction.mdx
+++ b/content/docs/nextjs-sdk/(Intents)/evmRawTransaction.mdx
@@ -22,6 +22,11 @@ There are two ways to implement raw transactions:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -47,9 +52,11 @@ function RawTransaction() {
                     value: BigInt("1000000000000000000") // 1 ETH // [!code highlight]
                 } // [!code highlight]
             }; // [!code highlight]
+
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
             
             // Execute the transaction
-            const jobId = await evmRawTransaction(oktoClient, rawTxParams); // [!code highlight]
+            const jobId = await evmRawTransaction(oktoClient, rawTxParams, feePayerAddress?); // [!code highlight]
             console.log('Transaction jobId:', jobId);
         } catch (error) {
             console.error('Error in raw transaction:', error);
@@ -84,8 +91,10 @@ function RawTransaction() {
                 } // [!code highlight]
             }; // [!code highlight]
 
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
             // Create the user operation
-            const userOp = await evmRawTransaction(oktoClient, rawTxParams); // [!code highlight]
+            const userOp = await evmRawTransaction(oktoClient, rawTxParams, feePayerAddress?); // [!code highlight]
             
             // Sign the operation
             const signedOp = await oktoClient.signUserOp(userOp); // [!code highlight]
@@ -300,6 +309,7 @@ Before using this function, ensure your target chain is an EVM-compatible chain 
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient obtained from useOkto hook | Yes |
 | `data` | `RawTransactionIntentParams` | Parameters for the raw transaction | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `RawTransactionIntentParams` contains:
 

--- a/content/docs/nextjs-sdk/(Intents)/nftTransfer.mdx
+++ b/content/docs/nextjs-sdk/(Intents)/nftTransfer.mdx
@@ -26,6 +26,10 @@ There are two ways to implement NFT transfers:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -50,9 +54,11 @@ function NFTTransfer() {
                 amount: 1, // [!code highlight]
                 nftType: 'ERC721' // [!code highlight]
             }; // [!code highlight]
+
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
             
             // Execute the transfer
-            const jobId = await nftTransfer(oktoClient, transferParams); // [!code highlight]
+            const jobId = await nftTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
             console.log('Transfer jobId:', jobId);
         } catch (error) {
             console.error('Error in NFT transfer:', error);
@@ -86,8 +92,10 @@ function NFTTransfer() {
                 nftType: 'ERC721' // [!code highlight]
             }; // [!code highlight]
 
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
             // Create the user operation
-            const userOp = await nftTransfer(oktoClient, transferParams); // [!code highlight]
+            const userOp = await nftTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
             
             // Sign the operation
             const signedOp = await oktoClient.signUserOp(userOp); // [!code highlight]
@@ -230,6 +238,7 @@ For error handling:
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient obtained from useOkto hook | Yes |
 | `data` | [`NFTTransferIntentParams`](/docs/nextjs-sdk/technical-reference#models) | Parameters for the NFT transfer | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `NFTTransferIntentParams` contains:
 

--- a/content/docs/nextjs-sdk/(Intents)/tokenTransfer.mdx
+++ b/content/docs/nextjs-sdk/(Intents)/tokenTransfer.mdx
@@ -23,6 +23,10 @@ There are two ways to implement token transfers:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -45,8 +49,11 @@ function TokenTransfer() {
                 token: "0x2170ed0880ac9a755fd29b2688956bd959f933f8", // Token contract address // [!code highlight]
                 caip2Id: "eip155:1" // [!code highlight]
             }; // [!code highlight]
+
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
             // Execute the transfer
-            const jobId = await tokenTransfer(oktoClient, transferParams); // [!code highlight]
+            const jobId = await tokenTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
             console.log('Transfer jobId:', jobId);
         } catch (error:any) {
             console.error('Error in token transfer:', error);
@@ -78,8 +85,10 @@ function TokenTransfer() {
                 caip2Id: "eip155:1" // [!code highlight]
             }; // [!code highlight]
 
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
             // Create the user operation
-            const userOp = await tokenTransfer(oktoClient, transferParams); // [!code highlight]
+            const userOp = await tokenTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
             
             // Sign the operation
             const signedOp = await oktoClient.signUserOp(userOp); // [!code highlight]
@@ -223,6 +232,7 @@ For error handling:
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient obtained from useOkto hook | Yes |
 | `data` | [`TokenTransferIntentParams`](/docs/nextjs-sdk/technical-reference#models) | Parameters for the token transfer | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `TokenTransferIntentParams` contains:
 

--- a/content/docs/nextjs-sdk/index.mdx
+++ b/content/docs/nextjs-sdk/index.mdx
@@ -51,7 +51,31 @@ import ViewOnGithub from 'app/components/mdx/ViewOnGithub';
     </CollapsibleCallout>
 
 </Step>
+<Step>
+    ## Sponsorship Setup (Optional)
 
+    To enable sponsorship for transactions via Okto, follow the steps below:
+    1. **Enable Supported Chains:** Ensure the chains you wish to sponsor transactions on are enabled in your [Okto Dashboard](https://dashboard.okto.tech) under **Chains & Tokens**.
+
+    2. **Create and Configure a Treasury Wallet:** Create at least one Treasury Wallet in your Okto Dashboard.
+    - For each supported chain:
+        - The Treasury Wallet used as the `feePayerAddress` must have its corresponding *destination chain address* funded with a small amount of native tokens for one-time verification.
+        - Refer to the [Treasury Wallet Docs](/docs/developer-admin-dashboard/treasury-wallet) for setup and verification details.
+
+    3. **Activate Sponsorship:** Navigate to the **Sponsorship** section in the Okto Dashboard and enable sponsorship for each chain individually.
+
+    4. **Fund the Sponsor Wallet:** Deposit a sufficient amount of native tokens into your Sponsor Wallet for each chain where sponsorship is active. These tokens will be used to cover user transaction fees.
+
+
+    <CollapsibleCallout type="note" title="Loading Funds to Sponsorship">
+
+        * Only native tokens of the respective chains can be loaded into sponsorship accounts.  
+        * Each chain has a unique sponsorship address. You can find this address in your Okto dashboard.  
+        * For testnets, you can use faucets to acquire tokens. 
+
+    </CollapsibleCallout>
+
+</Step>
 <Step>
     ## 1. Create Your NextJS App
 

--- a/content/docs/nextjs-sdk/meta.json
+++ b/content/docs/nextjs-sdk/meta.json
@@ -22,6 +22,8 @@
     "./wallets/overview",
     "./wallets/(embedded-wallets)/index",
     "./wallets/(embedded-wallets)/delegated-actions",
+    "./wallets/treasury-wallet",
+    "./wallets/sponsor-wallet",
     "!./wallets/external-wallets",
     "---Usage---",
     "usage-overview",

--- a/content/docs/nextjs-sdk/wallets/sponsor-wallet.mdx
+++ b/content/docs/nextjs-sdk/wallets/sponsor-wallet.mdx
@@ -1,0 +1,35 @@
+---
+title: Client Sponsor Wallet
+description: This guide explains how Sponsor Wallets enable gasless user transactions by funding gas fees across chains. 
+full: false
+---
+
+## Overview
+
+The Sponsor Wallet in the Okto ecosystem is dedicated to funding gas fees for user transactions. Its primary purpose is to enable a "gasless" experience for your end-users by having the client cover the transaction costs on supported blockchain networks.
+
+You can create and manage Sponsor Wallets through the [Okto Developer Dashboard](/docs/developer-admin-dashboard/sponsorship).
+
+**Key Characteristics:**
+
+- **Gas Fee Funding:** Holds the actual cryptocurrency (e.g., MATIC on Polygon, ETH on Base) that will be used to pay for sponsored user transactions.
+
+- **Dashboard Management:** Sponsor Wallets are primarily managed (enabled per chain, funded) through the Okto Developer Dashboard on the "Gas Sponsorship" page.
+
+- **Chain-Specific:** You will have different Sponsor Wallet addresses for each chain where you enable sponsorship. Each must be funded independently.
+
+- **Authorization via Treasury Wallet:** While the Sponsor Wallet provides the funds, the authorization to use these funds for a specific transaction comes from a **Treasury Wallet** designated as the `feePayerAddress` in the API call.
+
+## SDK Interaction & Gas Sponsorship
+
+Direct SDK interaction for *authenticating as* a Sponsor Wallet (like generating an auth token for it) is generally not applicable because its role is passive (holding funds). The SDK interactions related to sponsorship involve:
+
+1.  **Enabling Sponsorship (Dashboard):** You must first enable sponsorship for the desired chains on the "Gas Sponsorship" page of the Okto Developer Dashboard.
+
+2.  **Funding Sponsor Wallet (Dashboard):** Deposit funds into the Sponsor Wallet for each enabled chain using the "Deposit" button on the dashboard. **Crucially, do not airdrop funds directly to the displayed Sponsor Wallet address; use the "Deposit" function to avoid loss of funds.**
+
+3.  **Specifying `feePayerAddress` in API Calls (Client-Side/Backend):**
+    When you want a user's transaction to be sponsored, you must include the `feePayerAddress` field in the payload for `estimateUserOp`.
+    - This `feePayerAddress` **must be the User SWA of one of your valid Treasury Wallets.**
+    - If sponsorship is enabled for the chain and the `feePayerAddress` is correctly provided (and the Treasury Wallet is set up for sponsorship), the gas fees for the user's transaction will be deducted from your Sponsor Wallet for that chain.
+    - If sponsorship is disabled, or if the `feePayerAddress` is missing or invalid when sponsorship is active, the transaction will likely fail or the user will have to pay gas.

--- a/content/docs/nextjs-sdk/wallets/treasury-wallet.mdx
+++ b/content/docs/nextjs-sdk/wallets/treasury-wallet.mdx
@@ -32,6 +32,43 @@ The process is similar to generating an auth token for delegated actions with a 
 
 ---
 
+<Callout title="Important">
+Usage of Treasury Wallet is not supported via Okto SDKs and must be performed through backend API integration. Follow the implementation steps below to use a Treasury Wallet effectively in server-side workflows.
+</Callout>
+
+### Implementation Example
+
+The [`treasuryWallet_template.ts`](https://github.com/okto-hq/okto-sdkv2-ts-template/blob/main/src/api-template/auth/treasuryWallet_template.ts) script demonstrates how to generate this Okto Auth Token:
+
+- It uses the `treasuryWalletSWA` (the SWA of the specific Treasury Wallet you created on the dashboard).
+
+- It constructs a `sessionConfig` object containing `sessionPrivKey`, `sessionPubKey` (derived), and `treasuryWalletSWA`.
+
+- Finally, it invokes `getAuthorizationToken(sessionConfig)` to generate a bearer token. This token can then be used to authenticate subsequent API calls, including explorer functions and intent executions. For more details, refer to the [API References](/docs/openapi/getting-started#api-references).
+
+```typescript
+import { getAuthorizationToken } from "../utils/getAuthorizationToken.js"; 
+import { SessionKey } from "../utils/sessionKey.js"; 
+import dotenv from "dotenv";
+
+dotenv.config(); // Ensure your Treasury API Key is in .env
+
+const treasuryApiKey = process.env.OKTO_TREASURY_API_KEY; // Your Treasury API Key from Okto Dashboard
+const specificTreasuryWalletSWA = "0xYourTreasuryWalletSWAFromDashboard";
+
+const session = SessionKey.fromPrivateKey(treasuryApiKey); 
+
+const sessionConfig = { 
+   sessionPrivKey: session.privateKeyHexWith0x,
+   sessionPubKey: session.uncompressedPublicKeyHexWith0x,
+   treasuryWalletSWA: specificTreasuryWalletSWA, // Field name in this template
+   // or userSWA: specificTreasuryWalletSWA, // If adapting other templates
+ };
+
+ const authToken = await getAuthorizationToken(sessionConfig); 
+ console.log("Okto Treasury Wallet Auth Token: ", authToken);
+```
+
 <Callout title="Note">
 All Okto Explorer API functions (e.g., `getAccount`, `getPortfolio`) can be used with an auth token generated for a Treasury Wallet, just as they would for a user's SWA. The functionality remains the same; only the signing identity (and thus the data returned) changes based on the token.
 </Callout>

--- a/content/docs/nextjs-sdk/wallets/treasury-wallet.mdx
+++ b/content/docs/nextjs-sdk/wallets/treasury-wallet.mdx
@@ -1,0 +1,37 @@
+---
+title: Client Treasury Wallet
+description: This guide explains how to use Treasury Wallets for client-initiated on-chain actions, gas sponsorship, and API access via Auth Tokens.
+full: false
+---
+
+## Overview
+
+The Treasury Wallet in the Okto ecosystem serves as the client's own on-chain identity. Unlike user-specific Smart Wallet Accounts (SWAs), which are tied to end-users, Treasury Wallets are controlled by the client.
+
+**Key Purposes:**
+
+1.  **Client-Initiated On-Chain Operations:** Execute smart contract calls, send tokens (e.g., for airdrops), or perform any other on-chain transaction that the client needs to initiate directly, without relying on an end-user's wallet or action.
+
+2.  **Authorizing Gas Sponsorship:** When gas sponsorship is enabled for user transactions, a Treasury Wallet's User SWA must be specified as the `feePayerAddress`. This Treasury Wallet then authorizes the use of funds from the corresponding Sponsor Wallet to cover the gas fees.
+
+You can create and manage Treasury Wallets through the [Okto Developer Dashboard](/docs/developer-admin-dashboard/treasury-wallet).
+
+---
+
+## Generating an Okto Auth Token for a Treasury Wallet
+
+To interact with Okto APIs using a Treasury Wallet's identity (i.e., to sign and send transactions from a Treasury Wallet), you need to generate an Okto Auth Token specific to that Treasury Wallet.
+
+The process is similar to generating an auth token for delegated actions with a user's SWA, but the key components are sourced differently:
+
+1.  **Session Private Key (`sessionPrivKey`):** This is the **Treasury API Key** provided on the "API Key" page of your Okto Developer Dashboard. This key is unique to your client account and is used to authorize actions for *any* of your Treasury Wallets.
+
+2.  **Session Public Key (`sessionPubKey`):** This is derived from the Treasury API Key (Session Private Key).
+
+3.  **Treasury Wallet SWA (`treasuryWalletSWA` or `userSWA` in context):** This is the specific User SWA of the Treasury Wallet you wish to use for the transaction. You can find this address on the "Treasury Wallet" page of the dashboard after creating a wallet.
+
+---
+
+<Callout title="Note">
+All Okto Explorer API functions (e.g., `getAccount`, `getPortfolio`) can be used with an auth token generated for a Treasury Wallet, just as they would for a user's SWA. The functionality remains the same; only the signing identity (and thus the data returned) changes based on the token.
+</Callout>

--- a/content/docs/openapi/wallets/treasury-wallet.mdx
+++ b/content/docs/openapi/wallets/treasury-wallet.mdx
@@ -39,7 +39,7 @@ The [`treasuryWallet_template.ts`](https://github.com/okto-hq/okto-sdkv2-ts-temp
 
 - It constructs a `sessionConfig` object containing `sessionPrivKey`, `sessionPubKey` (derived), and `treasuryWalletSWA`.
 
-- Finally, it calls `getAuthorizationToken(sessionConfig)` to generate the bearer token.
+- Finally, it calls `getAuthorizationToken(sessionConfig)` to generate the bearer token. This token can then be used to authenticate subsequent API calls, including explorer functions and intent executions. For more details, refer to the [API References](/docs/openapi/getting-started#api-references).
 
 ```typescript
 import { getAuthorizationToken } from "../utils/getAuthorizationToken.js"; 

--- a/content/docs/react-native-sdk/(Intents)/evmRawTransaction.mdx
+++ b/content/docs/react-native-sdk/(Intents)/evmRawTransaction.mdx
@@ -23,6 +23,10 @@ There are two ways to implement raw transactions:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -49,9 +53,11 @@ function RawTransaction() {
                     value: BigInt("1000000000000000000") // 1 ETH // [!code highlight]
                 } // [!code highlight]
             }; // [!code highlight]
+
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
             
             // Execute the transaction
-            const jobId = await evmRawTransaction(oktoClient, rawTxParams); // [!code highlight]
+            const jobId = await evmRawTransaction(oktoClient, rawTxParams, feePayerAddress?); // [!code highlight]
             console.log('Transaction jobId:', jobId);
         } catch (error) {
             console.error('Error in raw transaction:', error);
@@ -86,9 +92,11 @@ function RawTransaction() {
                     value: BigInt("1000000000000000000") // 1 ETH // [!code highlight]
                 } // [!code highlight]
             }; // [!code highlight]
+
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
  
             // Create the user operation
-            const userOp = await evmRawTransaction(oktoClient, rawTxParams); // [!code highlight]
+            const userOp = await evmRawTransaction(oktoClient, rawTxParams, feePayerAddress?); // [!code highlight]
             
             // Sign the operation
             const signedOp = await oktoClient.signUserOp(userOp); // [!code highlight]
@@ -231,6 +239,7 @@ Before using this function, ensure your target chain is an EVM-compatible chain 
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient obtained from useOkto hook | Yes |
 | `data` | `RawTransactionIntentParams` | Parameters for the raw transaction | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `RawTransactionIntentParams` contains:
 

--- a/content/docs/react-native-sdk/(Intents)/nftTransfer.mdx
+++ b/content/docs/react-native-sdk/(Intents)/nftTransfer.mdx
@@ -27,6 +27,10 @@ There are two ways to implement NFT transfers:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -52,9 +56,11 @@ function NFTTransfer() {
                 amount: 1, // [!code highlight]
                 nftType: 'ERC721' // [!code highlight]
             }; // [!code highlight]
+
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
             
             // Execute the transfer
-            const jobId = await nftTransfer(oktoClient, transferParams); // [!code highlight]
+            const jobId = await nftTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
             console.log('Transfer jobId:', jobId);
         } catch (error) {
             console.error('Error in NFT transfer:', error);
@@ -89,8 +95,10 @@ function NFTTransfer() {
                 nftType: 'ERC721'
             };
 
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
             // Create the user operation
-            const userOp = await nftTransfer(oktoClient, transferParams);
+            const userOp = await nftTransfer(oktoClient, transferParams, feePayerAddress?);
             
             // Sign the operation
             const signedOp = await oktoClient.signUserOp(userOp);
@@ -232,6 +240,7 @@ For error handling:
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient obtained from useOkto hook | Yes |
 | `data` | [`NFTTransferIntentParams`](/docs/react-native-sdk/technical-reference#models) | Parameters for the NFT transfer | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `NFTTransferIntentParams` contains:
 

--- a/content/docs/react-native-sdk/(Intents)/tokenTransfer.mdx
+++ b/content/docs/react-native-sdk/(Intents)/tokenTransfer.mdx
@@ -23,6 +23,10 @@ There are two ways to implement token transfers:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -46,8 +50,11 @@ function TokenTransfer() {
                 token: "0x2170ed0880ac9a755fd29b2688956bd959f933f8", // Token contract address // [!code highlight]
                 caip2Id: "eip155:1" // [!code highlight]
             }; // [!code highlight]
+
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
             // Execute the transfer
-            const jobId = await tokenTransfer(oktoClient, transferParams); // [!code highlight]
+            const jobId = await tokenTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
             console.log('Transfer jobId:', jobId);
         } catch (error:any) {
             console.error('Error in token transfer:', error);
@@ -80,8 +87,10 @@ function TokenTransfer() {
                 caip2Id: "eip155:1" // [!code highlight]
             }; // [!code highlight]
 
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
             // Create the user operation
-            const userOp = await tokenTransfer(oktoClient, transferParams); // [!code highlight]
+            const userOp = await tokenTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
             
             // Sign the operation
             const signedOp = await oktoClient.signUserOp(userOp); // [!code highlight]
@@ -223,6 +232,7 @@ For error handling:
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient obtained from useOkto hook | Yes |
 | `data` | [`TokenTransferIntentParams`](/docs/react-native-sdk/technical-reference#models) | Parameters for the token transfer | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `TokenTransferIntentParams` contains:
 

--- a/content/docs/react-native-sdk/index.mdx
+++ b/content/docs/react-native-sdk/index.mdx
@@ -47,6 +47,32 @@ import ViewOnGithub from 'app/components/mdx/ViewOnGithub';
 </Step>
 
 <Step>
+    ## Sponsorship Setup (Optional)
+
+    To enable sponsorship for transactions via Okto, follow the steps below:
+    1. **Enable Supported Chains:** Ensure the chains you wish to sponsor transactions on are enabled in your [Okto Dashboard](https://dashboard.okto.tech) under **Chains & Tokens**.
+
+    2. **Create and Configure a Treasury Wallet:** Create at least one Treasury Wallet in your Okto Dashboard.
+    - For each supported chain:
+        - The Treasury Wallet used as the `feePayerAddress` must have its corresponding *destination chain address* funded with a small amount of native tokens for one-time verification.
+        - Refer to the [Treasury Wallet Docs](/docs/developer-admin-dashboard/treasury-wallet) for setup and verification details.
+
+    3. **Activate Sponsorship:** Navigate to the **Sponsorship** section in the Okto Dashboard and enable sponsorship for each chain individually.
+
+    4. **Fund the Sponsor Wallet:** Deposit a sufficient amount of native tokens into your Sponsor Wallet for each chain where sponsorship is active. These tokens will be used to cover user transaction fees.
+
+
+    <CollapsibleCallout type="note" title="Loading Funds to Sponsorship">
+
+        * Only native tokens of the respective chains can be loaded into sponsorship accounts.  
+        * Each chain has a unique sponsorship address. You can find this address in your Okto dashboard.  
+        * For testnets, you can use faucets to acquire tokens. 
+
+    </CollapsibleCallout>
+
+</Step>
+
+<Step>
     ## Initialize an Expo App
 
     Create a new Expo project:
@@ -306,6 +332,32 @@ import ViewOnGithub from 'app/components/mdx/ViewOnGithub';
         2. For iOS: [iOS Setup](/docs/react-native-sdk/authenticate-users/google-oauth/google-console-setup-ios)
         3. For Android: [Android Setup](/docs/react-native-sdk/authenticate-users/google-oauth/google-console-setup-android)
     </CollapsibleCallout>
+</Step>
+
+<Step>
+    ## Sponsorship Setup (Optional)
+
+    To enable sponsorship for transactions via Okto, follow the steps below:
+    1. **Enable Supported Chains:** Ensure the chains you wish to sponsor transactions on are enabled in your [Okto Dashboard](https://dashboard.okto.tech) under **Chains & Tokens**.
+
+    2. **Create and Configure a Treasury Wallet:** Create at least one Treasury Wallet in your Okto Dashboard.
+    - For each supported chain:
+        - The Treasury Wallet used as the `feePayerAddress` must have its corresponding *destination chain address* funded with a small amount of native tokens for one-time verification.
+        - Refer to the [Treasury Wallet Docs](/docs/developer-admin-dashboard/treasury-wallet) for setup and verification details.
+
+    3. **Activate Sponsorship:** Navigate to the **Sponsorship** section in the Okto Dashboard and enable sponsorship for each chain individually.
+
+    4. **Fund the Sponsor Wallet:** Deposit a sufficient amount of native tokens into your Sponsor Wallet for each chain where sponsorship is active. These tokens will be used to cover user transaction fees.
+
+
+    <CollapsibleCallout type="note" title="Loading Funds to Sponsorship">
+
+        * Only native tokens of the respective chains can be loaded into sponsorship accounts.  
+        * Each chain has a unique sponsorship address. You can find this address in your Okto dashboard.  
+        * For testnets, you can use faucets to acquire tokens. 
+
+    </CollapsibleCallout>
+
 </Step>
 
 <Step>

--- a/content/docs/react-native-sdk/meta.json
+++ b/content/docs/react-native-sdk/meta.json
@@ -29,6 +29,8 @@
     "./wallets/overview",
     "./wallets/(embedded-wallets)/index",
     "./wallets/(embedded-wallets)/delegated-actions",
+    "./wallets/treasury-wallet",
+    "./wallets/sponsor-wallet",
     "!./wallets/external-wallets",
     "./wallets/wagmi-integration",
     "---Resources---",

--- a/content/docs/react-native-sdk/wallets/sponsor-wallet.mdx
+++ b/content/docs/react-native-sdk/wallets/sponsor-wallet.mdx
@@ -1,0 +1,35 @@
+---
+title: Client Sponsor Wallet
+description: This guide explains how Sponsor Wallets enable gasless user transactions by funding gas fees across chains.
+full: false
+---
+
+## Overview
+
+The Sponsor Wallet in the Okto ecosystem is dedicated to funding gas fees for user transactions. Its primary purpose is to enable a "gasless" experience for your end-users by having the client cover the transaction costs on supported blockchain networks.
+
+You can create and manage Sponsor Wallets through the [Okto Developer Dashboard](/docs/developer-admin-dashboard/sponsorship).
+
+**Key Characteristics:**
+
+- **Gas Fee Funding:** Holds the actual cryptocurrency (e.g., MATIC on Polygon, ETH on Base) that will be used to pay for sponsored user transactions.
+
+- **Dashboard Management:** Sponsor Wallets are primarily managed (enabled per chain, funded) through the Okto Developer Dashboard on the "Gas Sponsorship" page.
+
+- **Chain-Specific:** You will have different Sponsor Wallet addresses for each chain where you enable sponsorship. Each must be funded independently.
+
+- **Authorization via Treasury Wallet:** While the Sponsor Wallet provides the funds, the authorization to use these funds for a specific transaction comes from a **Treasury Wallet** designated as the `feePayerAddress` in the API call.
+
+## SDK Interaction & Gas Sponsorship
+
+Direct SDK interaction for *authenticating as* a Sponsor Wallet (like generating an auth token for it) is generally not applicable because its role is passive (holding funds). The SDK interactions related to sponsorship involve:
+
+1.  **Enabling Sponsorship (Dashboard):** You must first enable sponsorship for the desired chains on the "Gas Sponsorship" page of the Okto Developer Dashboard.
+
+2.  **Funding Sponsor Wallet (Dashboard):** Deposit funds into the Sponsor Wallet for each enabled chain using the "Deposit" button on the dashboard. **Crucially, do not airdrop funds directly to the displayed Sponsor Wallet address; use the "Deposit" function to avoid loss of funds.**
+
+3.  **Specifying `feePayerAddress` in API Calls (Client-Side/Backend):**
+    When you want a user's transaction to be sponsored, you must include the `feePayerAddress` field in the payload for `estimateUserOp`.
+    - This `feePayerAddress` **must be the User SWA of one of your valid Treasury Wallets.**
+    - If sponsorship is enabled for the chain and the `feePayerAddress` is correctly provided (and the Treasury Wallet is set up for sponsorship), the gas fees for the user's transaction will be deducted from your Sponsor Wallet for that chain.
+    - If sponsorship is disabled, or if the `feePayerAddress` is missing or invalid when sponsorship is active, the transaction will likely fail or the user will have to pay gas.

--- a/content/docs/react-native-sdk/wallets/treasury-wallet.mdx
+++ b/content/docs/react-native-sdk/wallets/treasury-wallet.mdx
@@ -32,6 +32,43 @@ The process is similar to generating an auth token for delegated actions with a 
 
 ---
 
+<Callout title="Important">
+Usage of Treasury Wallet is not supported via Okto SDKs and must be performed through backend API integration. Follow the implementation steps below to use a Treasury Wallet effectively in server-side workflows.
+</Callout>
+
+### Implementation Example
+
+The [`treasuryWallet_template.ts`](https://github.com/okto-hq/okto-sdkv2-ts-template/blob/main/src/api-template/auth/treasuryWallet_template.ts) script demonstrates how to generate this Okto Auth Token:
+
+- It uses the `treasuryWalletSWA` (the SWA of the specific Treasury Wallet you created on the dashboard).
+
+- It constructs a `sessionConfig` object containing `sessionPrivKey`, `sessionPubKey` (derived), and `treasuryWalletSWA`.
+
+- Finally, it invokes `getAuthorizationToken(sessionConfig)` to generate a bearer token. This token can then be used to authenticate subsequent API calls, including explorer functions and intent executions. For more details, refer to the [API References](/docs/openapi/getting-started#api-references).
+
+```typescript
+import { getAuthorizationToken } from "../utils/getAuthorizationToken.js"; 
+import { SessionKey } from "../utils/sessionKey.js"; 
+import dotenv from "dotenv";
+
+dotenv.config(); // Ensure your Treasury API Key is in .env
+
+const treasuryApiKey = process.env.OKTO_TREASURY_API_KEY; // Your Treasury API Key from Okto Dashboard
+const specificTreasuryWalletSWA = "0xYourTreasuryWalletSWAFromDashboard";
+
+const session = SessionKey.fromPrivateKey(treasuryApiKey); 
+
+const sessionConfig = { 
+   sessionPrivKey: session.privateKeyHexWith0x,
+   sessionPubKey: session.uncompressedPublicKeyHexWith0x,
+   treasuryWalletSWA: specificTreasuryWalletSWA, // Field name in this template
+   // or userSWA: specificTreasuryWalletSWA, // If adapting other templates
+ };
+
+ const authToken = await getAuthorizationToken(sessionConfig); 
+ console.log("Okto Treasury Wallet Auth Token: ", authToken);
+```
+
 <Callout title="Note">
 All Okto Explorer API functions (e.g., `getAccount`, `getPortfolio`) can be used with an auth token generated for a Treasury Wallet, just as they would for a user's SWA. The functionality remains the same; only the signing identity (and thus the data returned) changes based on the token.
 </Callout>

--- a/content/docs/react-native-sdk/wallets/treasury-wallet.mdx
+++ b/content/docs/react-native-sdk/wallets/treasury-wallet.mdx
@@ -1,0 +1,37 @@
+---
+title: Client Treasury Wallet
+description: This guide explains how to use Treasury Wallets for client-initiated on-chain actions, gas sponsorship, and API access via Auth Tokens.
+full: false
+---
+
+## Overview
+
+The Treasury Wallet in the Okto ecosystem serves as the client's own on-chain identity. Unlike user-specific Smart Wallet Accounts (SWAs), which are tied to end-users, Treasury Wallets are controlled by the client.
+
+**Key Purposes:**
+
+1.  **Client-Initiated On-Chain Operations:** Execute smart contract calls, send tokens (e.g., for airdrops), or perform any other on-chain transaction that the client needs to initiate directly, without relying on an end-user's wallet or action.
+
+2.  **Authorizing Gas Sponsorship:** When gas sponsorship is enabled for user transactions, a Treasury Wallet's User SWA must be specified as the `feePayerAddress`. This Treasury Wallet then authorizes the use of funds from the corresponding Sponsor Wallet to cover the gas fees.
+
+You can create and manage Treasury Wallets through the [Okto Developer Dashboard](/docs/developer-admin-dashboard/treasury-wallet).
+
+---
+
+## Generating an Okto Auth Token for a Treasury Wallet
+
+To interact with Okto APIs using a Treasury Wallet's identity (i.e., to sign and send transactions from a Treasury Wallet), you need to generate an Okto Auth Token specific to that Treasury Wallet.
+
+The process is similar to generating an auth token for delegated actions with a user's SWA, but the key components are sourced differently:
+
+1.  **Session Private Key (`sessionPrivKey`):** This is the **Treasury API Key** provided on the "API Key" page of your Okto Developer Dashboard. This key is unique to your client account and is used to authorize actions for *any* of your Treasury Wallets.
+
+2.  **Session Public Key (`sessionPubKey`):** This is derived from the Treasury API Key (Session Private Key).
+
+3.  **Treasury Wallet SWA (`treasuryWalletSWA` or `userSWA` in context):** This is the specific User SWA of the Treasury Wallet you wish to use for the transaction. You can find this address on the "Treasury Wallet" page of the dashboard after creating a wallet.
+
+---
+
+<Callout title="Note">
+All Okto Explorer API functions (e.g., `getAccount`, `getPortfolio`) can be used with an auth token generated for a Treasury Wallet, just as they would for a user's SWA. The functionality remains the same; only the signing identity (and thus the data returned) changes based on the token.
+</Callout>

--- a/content/docs/react-sdk/(Intents)/evmRawTransaction.mdx
+++ b/content/docs/react-sdk/(Intents)/evmRawTransaction.mdx
@@ -22,6 +22,10 @@ There are two ways to implement raw transactions:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -47,9 +51,11 @@ function RawTransaction() {
                     value: BigInt("1000000000000000000") // 1 ETH // [!code highlight]
                 } // [!code highlight]
             }; // [!code highlight]
+
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
             
             // Execute the transaction
-            const jobId = await evmRawTransaction(oktoClient, rawTxParams); // [!code highlight]
+            const jobId = await evmRawTransaction(oktoClient, rawTxParams, feePayerAddress?); // [!code highlight]
             console.log('Transaction jobId:', jobId);
         } catch (error) {
             console.error('Error in raw transaction:', error);
@@ -84,8 +90,10 @@ function RawTransaction() {
                 } // [!code highlight]
             }; // [!code highlight]
 
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
             // Create the user operation
-            const userOp = await evmRawTransaction(oktoClient, rawTxParams); // [!code highlight]
+            const userOp = await evmRawTransaction(oktoClient, rawTxParams, feePayerAddress?); // [!code highlight]
             
             // Sign the operation
             const signedOp = await oktoClient.signUserOp(userOp); // [!code highlight]
@@ -299,6 +307,7 @@ Before using this function, ensure your target chain is an EVM-compatible chain 
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient obtained from useOkto hook | Yes |
 | `data` | `RawTransactionIntentParams` | Parameters for the raw transaction | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `RawTransactionIntentParams` contains:
 

--- a/content/docs/react-sdk/(Intents)/nftTransfer.mdx
+++ b/content/docs/react-sdk/(Intents)/nftTransfer.mdx
@@ -26,6 +26,10 @@ There are two ways to implement NFT transfers:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -50,9 +54,11 @@ function NFTTransfer() {
                 amount: 1, // [!code highlight]
                 nftType: 'ERC721' // [!code highlight]
             }; // [!code highlight]
+
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
             
             // Execute the transfer
-            const jobId = await nftTransfer(oktoClient, transferParams); // [!code highlight]
+            const jobId = await nftTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
             console.log('Transfer jobId:', jobId);
         } catch (error) {
             console.error('Error in NFT transfer:', error);
@@ -86,8 +92,10 @@ function NFTTransfer() {
                 nftType: 'ERC721' // [!code highlight]
             };
 
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
             // Create the user operation
-            const userOp = await nftTransfer(oktoClient, transferParams); // [!code highlight]
+            const userOp = await nftTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
             
             // Sign the operation
             const signedOp = await oktoClient.signUserOp(userOp); // [!code highlight]
@@ -230,6 +238,7 @@ For error handling:
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient obtained from useOkto hook | Yes |
 | `data` | [`NFTTransferIntentParams`](/docs/react-sdk/technical-reference#models) | Parameters for the NFT transfer | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `NFTTransferIntentParams` contains:
 

--- a/content/docs/react-sdk/(Intents)/tokenTransfer.mdx
+++ b/content/docs/react-sdk/(Intents)/tokenTransfer.mdx
@@ -23,6 +23,10 @@ There are two ways to implement token transfers:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -45,8 +49,11 @@ function TokenTransfer() {
                 token: "0x2170ed0880ac9a755fd29b2688956bd959f933f8", // Token contract address // [!code highlight]
                 caip2Id: "eip155:1" // [!code highlight]
             }; // [!code highlight]
+
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
             // Execute the transfer
-            const jobId = await tokenTransfer(oktoClient, transferParams); // [!code highlight]
+            const jobId = await tokenTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
             console.log('Transfer jobId:', jobId);
         } catch (error:any) {
             console.error('Error in token transfer:', error);
@@ -78,8 +85,10 @@ function TokenTransfer() {
                 caip2Id: "eip155:1" // [!code highlight]
             }; // [!code highlight]
 
+            const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
             // Create the user operation
-            const userOp = await tokenTransfer(oktoClient, transferParams); // [!code highlight]
+            const userOp = await tokenTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
             
             // Sign the operation
             const signedOp = await oktoClient.signUserOp(userOp); // [!code highlight]
@@ -170,7 +179,6 @@ To track a transaction to completion:
 </Callout>
 </Accordion>
 
-
 <Accordion title="Corresponding jobId Response">
 ```typescript
 // Order returned from getOrdersHistory
@@ -222,6 +230,7 @@ For error handling:
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient obtained from useOkto hook | Yes |
 | `data` | [`TokenTransferIntentParams`](/docs/react-sdk/technical-reference#models) | Parameters for the token transfer | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `TokenTransferIntentParams` contains:
 

--- a/content/docs/react-sdk/index.mdx
+++ b/content/docs/react-sdk/index.mdx
@@ -49,6 +49,32 @@ import ViewOnGithub from 'app/components/mdx/ViewOnGithub';
 </Step>
 
 <Step>
+    ## Sponsorship Setup (Optional)
+
+    To enable sponsorship for transactions via Okto, follow the steps below:
+    1. **Enable Supported Chains:** Ensure the chains you wish to sponsor transactions on are enabled in your [Okto Dashboard](https://dashboard.okto.tech) under **Chains & Tokens**.
+
+    2. **Create and Configure a Treasury Wallet:** Create at least one Treasury Wallet in your Okto Dashboard.
+    - For each supported chain:
+        - The Treasury Wallet used as the `feePayerAddress` must have its corresponding *destination chain address* funded with a small amount of native tokens for one-time verification.
+        - Refer to the [Treasury Wallet Docs](/docs/developer-admin-dashboard/treasury-wallet) for setup and verification details.
+
+    3. **Activate Sponsorship:** Navigate to the **Sponsorship** section in the Okto Dashboard and enable sponsorship for each chain individually.
+
+    4. **Fund the Sponsor Wallet:** Deposit a sufficient amount of native tokens into your Sponsor Wallet for each chain where sponsorship is active. These tokens will be used to cover user transaction fees.
+
+
+    <CollapsibleCallout type="note" title="Loading Funds to Sponsorship">
+
+        * Only native tokens of the respective chains can be loaded into sponsorship accounts.  
+        * Each chain has a unique sponsorship address. You can find this address in your Okto dashboard.  
+        * For testnets, you can use faucets to acquire tokens. 
+
+    </CollapsibleCallout>
+
+</Step>
+
+<Step>
     ## 1. Initialize a Vite React App
 
     If you already have a React app, you can skip this step and proceed directly to Step 2 to start integrating Okto.

--- a/content/docs/react-sdk/meta.json
+++ b/content/docs/react-sdk/meta.json
@@ -29,6 +29,8 @@
     "./wallets/overview",
     "./wallets/(embedded-wallets)/index",
     "./wallets/(embedded-wallets)/delegated-actions",
+    "./wallets/treasury-wallet",
+    "./wallets/sponsor-wallet",
     "!./wallets/external-wallets",
     "---Resources---",
     "[Dev Tools](/tools)",

--- a/content/docs/react-sdk/wallets/sponsor-wallet.mdx
+++ b/content/docs/react-sdk/wallets/sponsor-wallet.mdx
@@ -1,0 +1,35 @@
+---
+title: Client Sponsor Wallet
+description: This guide explains how Sponsor Wallets enable gasless user transactions by funding gas fees across chains.
+full: false
+---
+
+## Overview
+
+The Sponsor Wallet in the Okto ecosystem is dedicated to funding gas fees for user transactions. Its primary purpose is to enable a "gasless" experience for your end-users by having the client cover the transaction costs on supported blockchain networks.
+
+You can create and manage Sponsor Wallets through the [Okto Developer Dashboard](/docs/developer-admin-dashboard/sponsorship).
+
+**Key Characteristics:**
+
+- **Gas Fee Funding:** Holds the actual cryptocurrency (e.g., MATIC on Polygon, ETH on Base) that will be used to pay for sponsored user transactions.
+
+- **Dashboard Management:** Sponsor Wallets are primarily managed (enabled per chain, funded) through the Okto Developer Dashboard on the "Gas Sponsorship" page.
+
+- **Chain-Specific:** You will have different Sponsor Wallet addresses for each chain where you enable sponsorship. Each must be funded independently.
+
+- **Authorization via Treasury Wallet:** While the Sponsor Wallet provides the funds, the authorization to use these funds for a specific transaction comes from a **Treasury Wallet** designated as the `feePayerAddress` in the API call.
+
+## SDK Interaction & Gas Sponsorship
+
+Direct SDK interaction for *authenticating as* a Sponsor Wallet (like generating an auth token for it) is generally not applicable because its role is passive (holding funds). The SDK interactions related to sponsorship involve:
+
+1.  **Enabling Sponsorship (Dashboard):** You must first enable sponsorship for the desired chains on the "Gas Sponsorship" page of the Okto Developer Dashboard.
+
+2.  **Funding Sponsor Wallet (Dashboard):** Deposit funds into the Sponsor Wallet for each enabled chain using the "Deposit" button on the dashboard. **Crucially, do not airdrop funds directly to the displayed Sponsor Wallet address; use the "Deposit" function to avoid loss of funds.**
+
+3.  **Specifying `feePayerAddress` in API Calls (Client-Side/Backend):**
+    When you want a user's transaction to be sponsored, you must include the `feePayerAddress` field in the payload for `estimateUserOp`.
+    - This `feePayerAddress` **must be the User SWA of one of your valid Treasury Wallets.**
+    - If sponsorship is enabled for the chain and the `feePayerAddress` is correctly provided (and the Treasury Wallet is set up for sponsorship), the gas fees for the user's transaction will be deducted from your Sponsor Wallet for that chain.
+    - If sponsorship is disabled, or if the `feePayerAddress` is missing or invalid when sponsorship is active, the transaction will likely fail or the user will have to pay gas.

--- a/content/docs/react-sdk/wallets/treasury-wallet.mdx
+++ b/content/docs/react-sdk/wallets/treasury-wallet.mdx
@@ -1,0 +1,37 @@
+---
+title: Client Treasury Wallet
+description: This guide explains how to use Treasury Wallets for client-initiated on-chain actions, gas sponsorship, and API access via Auth Tokens.
+full: false
+---
+
+## Overview
+
+The Treasury Wallet in the Okto ecosystem serves as the client's own on-chain identity. Unlike user-specific Smart Wallet Accounts (SWAs), which are tied to end-users, Treasury Wallets are controlled by the client.
+
+**Key Purposes:**
+
+1.  **Client-Initiated On-Chain Operations:** Execute smart contract calls, send tokens (e.g., for airdrops), or perform any other on-chain transaction that the client needs to initiate directly, without relying on an end-user's wallet or action.
+
+2.  **Authorizing Gas Sponsorship:** When gas sponsorship is enabled for user transactions, a Treasury Wallet's User SWA must be specified as the `feePayerAddress`. This Treasury Wallet then authorizes the use of funds from the corresponding Sponsor Wallet to cover the gas fees.
+
+You can create and manage Treasury Wallets through the [Okto Developer Dashboard](/docs/developer-admin-dashboard/treasury-wallet).
+
+---
+
+## Generating an Okto Auth Token for a Treasury Wallet
+
+To interact with Okto APIs using a Treasury Wallet's identity (i.e., to sign and send transactions from a Treasury Wallet), you need to generate an Okto Auth Token specific to that Treasury Wallet.
+
+The process is similar to generating an auth token for delegated actions with a user's SWA, but the key components are sourced differently:
+
+1.  **Session Private Key (`sessionPrivKey`):** This is the **Treasury API Key** provided on the "API Key" page of your Okto Developer Dashboard. This key is unique to your client account and is used to authorize actions for *any* of your Treasury Wallets.
+
+2.  **Session Public Key (`sessionPubKey`):** This is derived from the Treasury API Key (Session Private Key).
+
+3.  **Treasury Wallet SWA (`treasuryWalletSWA` or `userSWA` in context):** This is the specific User SWA of the Treasury Wallet you wish to use for the transaction. You can find this address on the "Treasury Wallet" page of the dashboard after creating a wallet.
+
+---
+
+<Callout title="Note">
+All Okto Explorer API functions (e.g., `getAccount`, `getPortfolio`) can be used with an auth token generated for a Treasury Wallet, just as they would for a user's SWA. The functionality remains the same; only the signing identity (and thus the data returned) changes based on the token.
+</Callout>

--- a/content/docs/react-sdk/wallets/treasury-wallet.mdx
+++ b/content/docs/react-sdk/wallets/treasury-wallet.mdx
@@ -32,6 +32,44 @@ The process is similar to generating an auth token for delegated actions with a 
 
 ---
 
+
+<Callout title="Important">
+Usage of Treasury Wallet is not supported via Okto SDKs and must be performed through backend API integration. Follow the implementation steps below to use a Treasury Wallet effectively in server-side workflows.
+</Callout>
+
+### Implementation Example
+
+The [`treasuryWallet_template.ts`](https://github.com/okto-hq/okto-sdkv2-ts-template/blob/main/src/api-template/auth/treasuryWallet_template.ts) script demonstrates how to generate this Okto Auth Token:
+
+- It uses the `treasuryWalletSWA` (the SWA of the specific Treasury Wallet you created on the dashboard).
+
+- It constructs a `sessionConfig` object containing `sessionPrivKey`, `sessionPubKey` (derived), and `treasuryWalletSWA`.
+
+- Finally, it invokes `getAuthorizationToken(sessionConfig)` to generate a bearer token. This token can then be used to authenticate subsequent API calls, including explorer functions and intent executions. For more details, refer to the [API References](/docs/openapi/getting-started#api-references).
+
+```typescript
+import { getAuthorizationToken } from "../utils/getAuthorizationToken.js"; 
+import { SessionKey } from "../utils/sessionKey.js"; 
+import dotenv from "dotenv";
+
+dotenv.config(); // Ensure your Treasury API Key is in .env
+
+const treasuryApiKey = process.env.OKTO_TREASURY_API_KEY; // Your Treasury API Key from Okto Dashboard
+const specificTreasuryWalletSWA = "0xYourTreasuryWalletSWAFromDashboard";
+
+const session = SessionKey.fromPrivateKey(treasuryApiKey); 
+
+const sessionConfig = { 
+   sessionPrivKey: session.privateKeyHexWith0x,
+   sessionPubKey: session.uncompressedPublicKeyHexWith0x,
+   treasuryWalletSWA: specificTreasuryWalletSWA, // Field name in this template
+   // or userSWA: specificTreasuryWalletSWA, // If adapting other templates
+ };
+
+ const authToken = await getAuthorizationToken(sessionConfig); 
+ console.log("Okto Treasury Wallet Auth Token: ", authToken);
+```
+
 <Callout title="Note">
 All Okto Explorer API functions (e.g., `getAccount`, `getPortfolio`) can be used with an auth token generated for a Treasury Wallet, just as they would for a user's SWA. The functionality remains the same; only the signing identity (and thus the data returned) changes based on the token.
 </Callout>

--- a/content/docs/typescript-sdk/(Intents)/evmRawTransaction.mdx
+++ b/content/docs/typescript-sdk/(Intents)/evmRawTransaction.mdx
@@ -23,6 +23,10 @@ There are two ways to implement raw transactions:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -44,9 +48,11 @@ async function handleRawTransaction() {
                 value: BigInt("1000000000000000000") // 1 ETH // [!code highlight]
             } // [!code highlight]
         }; // [!code highlight]
+
+        const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
          
         // Execute the transaction
-        const jobId = await evmRawTransaction(oktoClient, rawTxParams); // [!code highlight]
+        const jobId = await evmRawTransaction(oktoClient, rawTxParams, feePayerAddress?); // [!code highlight]
         console.log('Transaction jobId:', jobId);
     } catch (error) {
         console.error('Error in raw transaction:', error);
@@ -70,8 +76,10 @@ async function handleRawTransaction() {
             } // [!code highlight]
         }; // [!code highlight]
 
+        const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
         // Create the user operation
-        const userOp = await evmRawTransaction(oktoClient, rawTxParams); // [!code highlight]
+        const userOp = await evmRawTransaction(oktoClient, rawTxParams, feePayerAddress?); // [!code highlight]
         
         // Sign the operation
         const signedOp = await oktoClient.signUserOp(userOp); // [!code highlight]
@@ -277,6 +285,7 @@ Before using this function, ensure your target chain is an EVM-compatible chain 
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient | Yes |
 | `data` | `RawTransactionIntentParams` | Parameters for the raw transaction | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `RawTransactionIntentParams` contains:
 

--- a/content/docs/typescript-sdk/(Intents)/nftTransfer.mdx
+++ b/content/docs/typescript-sdk/(Intents)/nftTransfer.mdx
@@ -29,6 +29,10 @@ There are two ways to implement NFT transfers:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -49,9 +53,11 @@ async function handleNFTTransfer() {
             amount: 1, // [!code highlight]
             nftType: 'ERC721' // [!code highlight]
         }; // [!code highlight]
+
+        const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
         
         // Execute the transfer
-        const jobId = await nftTransfer(oktoClient, transferParams); // [!code highlight]
+        const jobId = await nftTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
         console.log('Transfer jobId:', jobId);
     } catch (error) {
         console.error('Error in NFT transfer:', error);
@@ -74,8 +80,10 @@ async function handleNFTTransfer() {
             nftType: 'ERC721' // [!code highlight]
         }; // [!code highlight]
 
+        const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
         // Create the user operation
-        const userOp = await nftTransfer(oktoClient, transferParams); // [!code highlight]
+        const userOp = await nftTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
         
         // Sign the operation
         const signedOp = await oktoClient.signUserOp(userOp); // [!code highlight]
@@ -209,6 +217,7 @@ For error handling:
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient | Yes |
 | `data` | [`NFTTransferIntentParams`](/docs/typescript-sdk/technical-reference#models) | Parameters for the NFT transfer | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `NFTTransferIntentParams` contains:
 

--- a/content/docs/typescript-sdk/(Intents)/tokenTransfer.mdx
+++ b/content/docs/typescript-sdk/(Intents)/tokenTransfer.mdx
@@ -25,6 +25,10 @@ There are two ways to implement token transfers:
 - **UserOp Flow**: A granular approach where you manually control the creation, signing, and execution of the user operation. Useful for custom implementations or advanced use cases.
 </Callout>
 
+<Callout>
+If sponsorship is enabled for your user, you must pass the `feePayerAddress` (i.e., the Treasury Wallet address) as a parameter to the intent function. Refer to the example below for implementation details.
+</Callout>
+
 ### Example
 
 <Accordions defaultValue="Usage">
@@ -44,8 +48,10 @@ async function handleTokenTransfer() {
             caip2Id: "eip155:1" // [!code highlight]
         }; // [!code highlight]
 
+        const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
         // Execute the transfer
-        const jobId = await tokenTransfer(oktoClient, transferParams); // [!code highlight]
+        const jobId = await tokenTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
         console.log('Transfer jobId:', jobId);
     } catch (error) {
         console.error('Error in token transfer:', error);
@@ -66,8 +72,10 @@ async function handleTokenTransfer() {
             caip2Id: "eip155:1" // [!code highlight]
         }; // [!code highlight]
 
+        const feePayerAddress = "0xdb9B5..." // feePayerAddress used when sponsorship is available
+
         // Create the user operation
-        const userOp = await tokenTransfer(oktoClient, transferParams); // [!code highlight]
+        const userOp = await tokenTransfer(oktoClient, transferParams, feePayerAddress?); // [!code highlight]
         
         // Sign the operation
         const signedOp = await oktoClient.signUserOp(userOp); // [!code highlight]
@@ -201,6 +209,7 @@ For error handling:
 |-----------|------|-------------|----------|
 | `oktoClient` | `OktoClient` | Instance of OktoClient | Yes |
 | `data` | [`TokenTransferIntentParams`](/docs/typescript-sdk/technical-reference#models) | Parameters for the token transfer | Yes |
+| `feePayerAddress` | `string` | Address of the Treasury Wallet responsible for covering gas fees when sponsorship is enabled | Optional |
 
 Where `TokenTransferIntentParams` contains:
 

--- a/content/docs/typescript-sdk/index.mdx
+++ b/content/docs/typescript-sdk/index.mdx
@@ -52,6 +52,32 @@ This approach shows how to create a TypeScript application and manually configur
 </Step>
 
 <Step>
+    ## Sponsorship Setup (Optional)
+
+    To enable sponsorship for transactions via Okto, follow the steps below:
+    1. **Enable Supported Chains:** Ensure the chains you wish to sponsor transactions on are enabled in your [Okto Dashboard](https://dashboard.okto.tech) under **Chains & Tokens**.
+
+    2. **Create and Configure a Treasury Wallet:** Create at least one Treasury Wallet in your Okto Dashboard.
+    - For each supported chain:
+        - The Treasury Wallet used as the `feePayerAddress` must have its corresponding *destination chain address* funded with a small amount of native tokens for one-time verification.
+        - Refer to the [Treasury Wallet Docs](/docs/developer-admin-dashboard/treasury-wallet) for setup and verification details.
+
+    3. **Activate Sponsorship:** Navigate to the **Sponsorship** section in the Okto Dashboard and enable sponsorship for each chain individually.
+
+    4. **Fund the Sponsor Wallet:** Deposit a sufficient amount of native tokens into your Sponsor Wallet for each chain where sponsorship is active. These tokens will be used to cover user transaction fees.
+
+
+    <CollapsibleCallout type="note" title="Loading Funds to Sponsorship">
+
+        * Only native tokens of the respective chains can be loaded into sponsorship accounts.  
+        * Each chain has a unique sponsorship address. You can find this address in your Okto dashboard.  
+        * For testnets, you can use faucets to acquire tokens. 
+
+    </CollapsibleCallout>
+
+</Step>
+
+<Step>
     ## Initialize a TypeScript Project
 
     If you already have a TypeScript project, you can skip this step and proceed directly to Step 2 to start integrating Okto.

--- a/content/docs/typescript-sdk/meta.json
+++ b/content/docs/typescript-sdk/meta.json
@@ -28,6 +28,8 @@
         "./wallets/overview",
         "./wallets/(embedded-wallets)/index",
         "./wallets/(embedded-wallets)/delegated-actions",
+        "./wallets/treasury-wallet",
+        "./wallets/sponsor-wallet",
         "!./wallets/external-wallets",
         "---Resources---",
         "[Dev Tools](/tools)",

--- a/content/docs/typescript-sdk/wallets/sponsor-wallet.mdx
+++ b/content/docs/typescript-sdk/wallets/sponsor-wallet.mdx
@@ -1,0 +1,35 @@
+---
+title: Client Sponsor Wallet
+description: This guide explains how Sponsor Wallets enable gasless user transactions by funding gas fees across chains.
+full: false
+---
+
+## Overview
+
+The Sponsor Wallet in the Okto ecosystem is dedicated to funding gas fees for user transactions. Its primary purpose is to enable a "gasless" experience for your end-users by having the client cover the transaction costs on supported blockchain networks.
+
+You can create and manage Sponsor Wallets through the [Okto Developer Dashboard](/docs/developer-admin-dashboard/sponsorship).
+
+**Key Characteristics:**
+
+- **Gas Fee Funding:** Holds the actual cryptocurrency (e.g., MATIC on Polygon, ETH on Base) that will be used to pay for sponsored user transactions.
+
+- **Dashboard Management:** Sponsor Wallets are primarily managed (enabled per chain, funded) through the Okto Developer Dashboard on the "Gas Sponsorship" page.
+
+- **Chain-Specific:** You will have different Sponsor Wallet addresses for each chain where you enable sponsorship. Each must be funded independently.
+
+- **Authorization via Treasury Wallet:** While the Sponsor Wallet provides the funds, the authorization to use these funds for a specific transaction comes from a **Treasury Wallet** designated as the `feePayerAddress` in the API call.
+
+## SDK Interaction & Gas Sponsorship
+
+Direct SDK interaction for *authenticating as* a Sponsor Wallet (like generating an auth token for it) is generally not applicable because its role is passive (holding funds). The SDK interactions related to sponsorship involve:
+
+1.  **Enabling Sponsorship (Dashboard):** You must first enable sponsorship for the desired chains on the "Gas Sponsorship" page of the Okto Developer Dashboard.
+
+2.  **Funding Sponsor Wallet (Dashboard):** Deposit funds into the Sponsor Wallet for each enabled chain using the "Deposit" button on the dashboard. **Crucially, do not airdrop funds directly to the displayed Sponsor Wallet address; use the "Deposit" function to avoid loss of funds.**
+
+3.  **Specifying `feePayerAddress` in API Calls (Client-Side/Backend):**
+    When you want a user's transaction to be sponsored, you must include the `feePayerAddress` field in the payload for `estimateUserOp`.
+    - This `feePayerAddress` **must be the User SWA of one of your valid Treasury Wallets.**
+    - If sponsorship is enabled for the chain and the `feePayerAddress` is correctly provided (and the Treasury Wallet is set up for sponsorship), the gas fees for the user's transaction will be deducted from your Sponsor Wallet for that chain.
+    - If sponsorship is disabled, or if the `feePayerAddress` is missing or invalid when sponsorship is active, the transaction will likely fail or the user will have to pay gas.

--- a/content/docs/typescript-sdk/wallets/treasury-wallet.mdx
+++ b/content/docs/typescript-sdk/wallets/treasury-wallet.mdx
@@ -32,6 +32,43 @@ The process is similar to generating an auth token for delegated actions with a 
 
 ---
 
+<Callout title="Important">
+Usage of Treasury Wallet is not supported via Okto SDKs and must be performed through backend API integration. Follow the implementation steps below to use a Treasury Wallet effectively in server-side workflows.
+</Callout>
+
+### Implementation Example
+
+The [`treasuryWallet_template.ts`](https://github.com/okto-hq/okto-sdkv2-ts-template/blob/main/src/api-template/auth/treasuryWallet_template.ts) script demonstrates how to generate this Okto Auth Token:
+
+- It uses the `treasuryWalletSWA` (the SWA of the specific Treasury Wallet you created on the dashboard).
+
+- It constructs a `sessionConfig` object containing `sessionPrivKey`, `sessionPubKey` (derived), and `treasuryWalletSWA`.
+
+- Finally, it invokes `getAuthorizationToken(sessionConfig)` to generate a bearer token. This token can then be used to authenticate subsequent API calls, including explorer functions and intent executions. For more details, refer to the [API References](/docs/openapi/getting-started#api-references).
+
+```typescript
+import { getAuthorizationToken } from "../utils/getAuthorizationToken.js"; 
+import { SessionKey } from "../utils/sessionKey.js"; 
+import dotenv from "dotenv";
+
+dotenv.config(); // Ensure your Treasury API Key is in .env
+
+const treasuryApiKey = process.env.OKTO_TREASURY_API_KEY; // Your Treasury API Key from Okto Dashboard
+const specificTreasuryWalletSWA = "0xYourTreasuryWalletSWAFromDashboard";
+
+const session = SessionKey.fromPrivateKey(treasuryApiKey); 
+
+const sessionConfig = { 
+   sessionPrivKey: session.privateKeyHexWith0x,
+   sessionPubKey: session.uncompressedPublicKeyHexWith0x,
+   treasuryWalletSWA: specificTreasuryWalletSWA, // Field name in this template
+   // or userSWA: specificTreasuryWalletSWA, // If adapting other templates
+ };
+
+ const authToken = await getAuthorizationToken(sessionConfig); 
+ console.log("Okto Treasury Wallet Auth Token: ", authToken);
+```
+
 <Callout title="Note">
 All Okto Explorer API functions (e.g., `getAccount`, `getPortfolio`) can be used with an auth token generated for a Treasury Wallet, just as they would for a user's SWA. The functionality remains the same; only the signing identity (and thus the data returned) changes based on the token.
 </Callout>

--- a/content/docs/typescript-sdk/wallets/treasury-wallet.mdx
+++ b/content/docs/typescript-sdk/wallets/treasury-wallet.mdx
@@ -1,0 +1,37 @@
+---
+title: Client Treasury Wallet
+description: This guide explains how to use Treasury Wallets for client-initiated on-chain actions, gas sponsorship, and API access via Auth Tokens.
+full: false
+---
+
+## Overview
+
+The Treasury Wallet in the Okto ecosystem serves as the client's own on-chain identity. Unlike user-specific Smart Wallet Accounts (SWAs), which are tied to end-users, Treasury Wallets are controlled by the client.
+
+**Key Purposes:**
+
+1.  **Client-Initiated On-Chain Operations:** Execute smart contract calls, send tokens (e.g., for airdrops), or perform any other on-chain transaction that the client needs to initiate directly, without relying on an end-user's wallet or action.
+
+2.  **Authorizing Gas Sponsorship:** When gas sponsorship is enabled for user transactions, a Treasury Wallet's User SWA must be specified as the `feePayerAddress`. This Treasury Wallet then authorizes the use of funds from the corresponding Sponsor Wallet to cover the gas fees.
+
+You can create and manage Treasury Wallets through the [Okto Developer Dashboard](/docs/developer-admin-dashboard/treasury-wallet).
+
+---
+
+## Generating an Okto Auth Token for a Treasury Wallet
+
+To interact with Okto APIs using a Treasury Wallet's identity (i.e., to sign and send transactions from a Treasury Wallet), you need to generate an Okto Auth Token specific to that Treasury Wallet.
+
+The process is similar to generating an auth token for delegated actions with a user's SWA, but the key components are sourced differently:
+
+1.  **Session Private Key (`sessionPrivKey`):** This is the **Treasury API Key** provided on the "API Key" page of your Okto Developer Dashboard. This key is unique to your client account and is used to authorize actions for *any* of your Treasury Wallets.
+
+2.  **Session Public Key (`sessionPubKey`):** This is derived from the Treasury API Key (Session Private Key).
+
+3.  **Treasury Wallet SWA (`treasuryWalletSWA` or `userSWA` in context):** This is the specific User SWA of the Treasury Wallet you wish to use for the transaction. You can find this address on the "Treasury Wallet" page of the dashboard after creating a wallet.
+
+---
+
+<Callout title="Note">
+All Okto Explorer API functions (e.g., `getAccount`, `getPortfolio`) can be used with an auth token generated for a Treasury Wallet, just as they would for a user's SWA. The functionality remains the same; only the signing identity (and thus the data returned) changes based on the token.
+</Callout>

--- a/content/docs/unity-sdk/index.mdx
+++ b/content/docs/unity-sdk/index.mdx
@@ -53,6 +53,32 @@ import Link from "next/link";
 </Step>
 
 <Step>
+    ## Sponsorship Setup (Optional)
+
+    To enable sponsorship for transactions via Okto, follow the steps below:
+    1. **Enable Supported Chains:** Ensure the chains you wish to sponsor transactions on are enabled in your [Okto Dashboard](https://dashboard.okto.tech) under **Chains & Tokens**.
+
+    2. **Create and Configure a Treasury Wallet:** Create at least one Treasury Wallet in your Okto Dashboard.
+    - For each supported chain:
+        - The Treasury Wallet used as the `feePayerAddress` must have its corresponding *destination chain address* funded with a small amount of native tokens for one-time verification.
+        - Refer to the [Treasury Wallet Docs](/docs/developer-admin-dashboard/treasury-wallet) for setup and verification details.
+
+    3. **Activate Sponsorship:** Navigate to the **Sponsorship** section in the Okto Dashboard and enable sponsorship for each chain individually.
+
+    4. **Fund the Sponsor Wallet:** Deposit a sufficient amount of native tokens into your Sponsor Wallet for each chain where sponsorship is active. These tokens will be used to cover user transaction fees.
+
+
+    <CollapsibleCallout type="note" title="Loading Funds to Sponsorship">
+
+        * Only native tokens of the respective chains can be loaded into sponsorship accounts.  
+        * Each chain has a unique sponsorship address. You can find this address in your Okto dashboard.  
+        * For testnets, you can use faucets to acquire tokens. 
+
+    </CollapsibleCallout>
+
+</Step>
+
+<Step>
     ## 1. Create a new Unity project.
 
     If you already have a Unity project, you can skip this step and proceed directly to Step 2 to start integrating Okto.

--- a/content/docs/unity-sdk/meta.json
+++ b/content/docs/unity-sdk/meta.json
@@ -30,6 +30,8 @@
     "./wallets/(embedded-wallets)/index",
     "!./wallets/(embedded-wallets)/delegated-actions",
     "!./wallets/external-wallets",
+    "./wallets/treasury-wallet",
+    "./wallets/sponsor-wallet",
     "!./wallets/wagmi-integration",
     "---Resources---",
     "v2migration",

--- a/content/docs/unity-sdk/wallets/sponsor-wallet.mdx
+++ b/content/docs/unity-sdk/wallets/sponsor-wallet.mdx
@@ -1,0 +1,35 @@
+---
+title: Client Sponsor Wallet
+description: This guide explains how Sponsor Wallets enable gasless user transactions by funding gas fees across chains.
+full: false
+---
+
+## Overview
+
+The Sponsor Wallet in the Okto ecosystem is dedicated to funding gas fees for user transactions. Its primary purpose is to enable a "gasless" experience for your end-users by having the client cover the transaction costs on supported blockchain networks.
+
+You can create and manage Sponsor Wallets through the [Okto Developer Dashboard](/docs/developer-admin-dashboard/sponsorship).
+
+**Key Characteristics:**
+
+- **Gas Fee Funding:** Holds the actual cryptocurrency (e.g., MATIC on Polygon, ETH on Base) that will be used to pay for sponsored user transactions.
+
+- **Dashboard Management:** Sponsor Wallets are primarily managed (enabled per chain, funded) through the Okto Developer Dashboard on the "Gas Sponsorship" page.
+
+- **Chain-Specific:** You will have different Sponsor Wallet addresses for each chain where you enable sponsorship. Each must be funded independently.
+
+- **Authorization via Treasury Wallet:** While the Sponsor Wallet provides the funds, the authorization to use these funds for a specific transaction comes from a **Treasury Wallet** designated as the `feePayerAddress` in the API call.
+
+## SDK Interaction & Gas Sponsorship
+
+Direct SDK interaction for *authenticating as* a Sponsor Wallet (like generating an auth token for it) is generally not applicable because its role is passive (holding funds). The SDK interactions related to sponsorship involve:
+
+1.  **Enabling Sponsorship (Dashboard):** You must first enable sponsorship for the desired chains on the "Gas Sponsorship" page of the Okto Developer Dashboard.
+
+2.  **Funding Sponsor Wallet (Dashboard):** Deposit funds into the Sponsor Wallet for each enabled chain using the "Deposit" button on the dashboard. **Crucially, do not airdrop funds directly to the displayed Sponsor Wallet address; use the "Deposit" function to avoid loss of funds.**
+
+3.  **Specifying `feePayerAddress` in SDK Calls (Client-Side/Backend):**
+    When you want a user's transaction to be sponsored, you must include the `feePayerAddress` field in the payload for `estimateUserOp`.
+    - This `feePayerAddress` **must be the User SWA of one of your valid Treasury Wallets.**
+    - If sponsorship is enabled for the chain and the `feePayerAddress` is correctly provided (and the Treasury Wallet is set up for sponsorship), the gas fees for the user's transaction will be deducted from your Sponsor Wallet for that chain.
+    - If sponsorship is disabled, or if the `feePayerAddress` is missing or invalid when sponsorship is active, the transaction will likely fail or the user will have to pay gas.

--- a/content/docs/unity-sdk/wallets/treasury-wallet.mdx
+++ b/content/docs/unity-sdk/wallets/treasury-wallet.mdx
@@ -32,6 +32,43 @@ The process is similar to generating an auth token for delegated actions with a 
 
 ---
 
+<Callout title="Important">
+Usage of Treasury Wallet is not supported via Okto SDKs and must be performed through backend API integration. Follow the implementation steps below to use a Treasury Wallet effectively in server-side workflows.
+</Callout>
+
+### Implementation Example
+
+The [`treasuryWallet_template.ts`](https://github.com/okto-hq/okto-sdkv2-ts-template/blob/main/src/api-template/auth/treasuryWallet_template.ts) script demonstrates how to generate this Okto Auth Token:
+
+- It uses the `treasuryWalletSWA` (the SWA of the specific Treasury Wallet you created on the dashboard).
+
+- It constructs a `sessionConfig` object containing `sessionPrivKey`, `sessionPubKey` (derived), and `treasuryWalletSWA`.
+
+- Finally, it invokes `getAuthorizationToken(sessionConfig)` to generate a bearer token. This token can then be used to authenticate subsequent API calls, including explorer functions and intent executions. For more details, refer to the [API References](/docs/openapi/getting-started#api-references).
+
+```typescript
+import { getAuthorizationToken } from "../utils/getAuthorizationToken.js"; 
+import { SessionKey } from "../utils/sessionKey.js"; 
+import dotenv from "dotenv";
+
+dotenv.config(); // Ensure your Treasury API Key is in .env
+
+const treasuryApiKey = process.env.OKTO_TREASURY_API_KEY; // Your Treasury API Key from Okto Dashboard
+const specificTreasuryWalletSWA = "0xYourTreasuryWalletSWAFromDashboard";
+
+const session = SessionKey.fromPrivateKey(treasuryApiKey); 
+
+const sessionConfig = { 
+   sessionPrivKey: session.privateKeyHexWith0x,
+   sessionPubKey: session.uncompressedPublicKeyHexWith0x,
+   treasuryWalletSWA: specificTreasuryWalletSWA, // Field name in this template
+   // or userSWA: specificTreasuryWalletSWA, // If adapting other templates
+ };
+
+ const authToken = await getAuthorizationToken(sessionConfig); 
+ console.log("Okto Treasury Wallet Auth Token: ", authToken);
+```
+
 <Callout title="Note">
 All Okto Explorer API functions (e.g., `getAccount`, `getPortfolio`) can be used with an auth token generated for a Treasury Wallet, just as they would for a user's SWA. The functionality remains the same; only the signing identity (and thus the data returned) changes based on the token.
 </Callout>

--- a/content/docs/unity-sdk/wallets/treasury-wallet.mdx
+++ b/content/docs/unity-sdk/wallets/treasury-wallet.mdx
@@ -1,0 +1,37 @@
+---
+title: Client Treasury Wallet
+description: This guide explains how to use Treasury Wallets for client-initiated on-chain actions, gas sponsorship, and API access via Auth Tokens.
+full: false
+---
+
+## Overview
+
+The Treasury Wallet in the Okto ecosystem serves as the client's own on-chain identity. Unlike user-specific Smart Wallet Accounts (SWAs), which are tied to end-users, Treasury Wallets are controlled by the client.
+
+**Key Purposes:**
+
+1.  **Client-Initiated On-Chain Operations:** Execute smart contract calls, send tokens (e.g., for airdrops), or perform any other on-chain transaction that the client needs to initiate directly, without relying on an end-user's wallet or action.
+
+2.  **Authorizing Gas Sponsorship:** When gas sponsorship is enabled for user transactions, a Treasury Wallet's User SWA must be specified as the `feePayerAddress`. This Treasury Wallet then authorizes the use of funds from the corresponding Sponsor Wallet to cover the gas fees.
+
+You can create and manage Treasury Wallets through the [Okto Developer Dashboard](/docs/developer-admin-dashboard/treasury-wallet).
+
+---
+
+## Generating an Okto Auth Token for a Treasury Wallet
+
+To interact with Okto APIs using a Treasury Wallet's identity (i.e., to sign and send transactions from a Treasury Wallet), you need to generate an Okto Auth Token specific to that Treasury Wallet.
+
+The process is similar to generating an auth token for delegated actions with a user's SWA, but the key components are sourced differently:
+
+1.  **Session Private Key (`sessionPrivKey`):** This is the **Treasury API Key** provided on the "API Key" page of your Okto Developer Dashboard. This key is unique to your client account and is used to authorize actions for *any* of your Treasury Wallets.
+
+2.  **Session Public Key (`sessionPubKey`):** This is derived from the Treasury API Key (Session Private Key).
+
+3.  **Treasury Wallet SWA (`treasuryWalletSWA` or `userSWA` in context):** This is the specific User SWA of the Treasury Wallet you wish to use for the transaction. You can find this address on the "Treasury Wallet" page of the dashboard after creating a wallet.
+
+---
+
+<Callout title="Note">
+All Okto Explorer API functions (e.g., `getAccount`, `getPortfolio`) can be used with an auth token generated for a Treasury Wallet, just as they would for a user's SWA. The functionality remains the same; only the signing identity (and thus the data returned) changes based on the token.
+</Callout>


### PR DESCRIPTION
SDK section modified: React, NextJS, TS, React-Native, Unity

Changes address in the PR:
- Add the client sponsor wallet and treasury wallet guide to all SDKs
- Add how to enable sponsorship step in quickstart for all SDKs
- Add `feePayerAddress` param to all intents across all SDKs